### PR TITLE
Remove dead references to Route53

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Creates the following resources:
 
 * ALB with separate target groups for HTTP and HTTPS.
 * Security Groups for the ALB.
-* Route53 A record pointing to the ALB.
 
 The HTTPS listener uses an Amazon certificate.
 
@@ -17,7 +16,6 @@ module "app_alb" {
 
   name           = "app"
   environment    = "prod"
-  zone_name      = "example.com"
   logs_s3_bucket = "my-aws-logs"
 
   alb_vpc_id             = "${module.vpc.vpc_id}"
@@ -45,7 +43,6 @@ module "app_alb" {
 | https_container_success_codes | The HTTP codes to use when checking for a successful response from the HTTPS container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | string | `200` | no |
 | logs_s3_bucket | S3 bucket for storing Application Load Balancer logs. | string | - | yes |
 | name | The service name. | string | - | yes |
-| zone_name | Route53 zone name. | string | - | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@
  *
  * * ALB with separate target groups for HTTP and HTTPS.
  * * Security Groups for the ALB.
- * * Route53 A record pointing to the ALB.
  *
  * The HTTPS listener uses an Amazon certificate.
 
@@ -17,7 +16,6 @@
  *
  *   name           = "app"
  *   environment    = "prod"
- *   zone_name      = "example.com"
  *   logs_s3_bucket = "my-aws-logs"
  *
  *   alb_vpc_id             = "${module.vpc.vpc_id}"
@@ -26,10 +24,6 @@
  * }
  * ```
  */
-
-locals {
-  fqdn = "${var.name}.${var.environment}.${var.zone_name}"
-}
 
 #
 # SG - ALB

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,6 @@ variable "environment" {
   type        = "string"
 }
 
-variable "zone_name" {
-  description = "Route53 zone name."
-  type        = "string"
-}
-
 variable "logs_s3_bucket" {
   description = "S3 bucket for storing Application Load Balancer logs."
   type        = "string"


### PR DESCRIPTION
Apparently we pulled out the Route53 stuff without updating the vars, etc. This cleans things up.