### PR TITLE
Fix the variable name for the certifcate ARN to not be ACM specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Creates the following resources:
 * Security Groups for the ALB.
 * Route53 A record pointing to the ALB.
 
-The HTTPS listener uses an Amazon certificate.
+The HTTPS listener uses a certificate stored in ACM or IAM.
 
 ## Usage
 
@@ -31,7 +31,7 @@ module "app_alb" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb_acm_arn | The ARN of the ACM certificate to be attached to the ALB. | string | - | yes |
+| alb_certificate_arn | The ARN of the certificate to be attached to the ALB. | string | - | yes |
 | alb_subnet_ids | Subnets IDs for the ALB. | list | - | yes |
 | alb_vpc_id | VPC ID to be used by the ALB. | string | - | yes |
 | environment | Environment tag, e.g prod. | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  * * Security Groups for the ALB.
  * * Route53 A record pointing to the ALB.
  *
- * The HTTPS listener uses an Amazon certificate.
+ * The HTTPS listener uses a certificate stored in ACM or IAM.
 
  * ## Usage
  *
@@ -135,7 +135,7 @@ resource "aws_alb_listener" "https" {
   load_balancer_arn = "${aws_alb.main.id}"
   port              = "443"
   protocol          = "HTTPS"
-  certificate_arn   = "${var.alb_acm_arn}"
+  certificate_arn   = "${var.alb_certificate_arn}"
 
   default_action {
     target_group_arn = "${aws_alb_target_group.https.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,8 @@ variable "logs_s3_bucket" {
   type        = "string"
 }
 
-variable "alb_acm_arn" {
-  description = "The ARN of the ACM certificate to be attached to the ALB."
+variable "alb_certificate_arn" {
+  description = "The ARN of the certificate to be attached to the ALB."
   type        = "string"
 }
 


### PR DESCRIPTION
Before ACM, folks could store certs in IAM. Passing in the ARN of those certs works fine.