### PR TITLE
Drop support for HTTP containers; instead use the redirect action

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,8 @@ module "app_alb" {
 | alb_subnet_ids | Subnets IDs for the ALB. | list | - | yes |
 | alb_vpc_id | VPC ID to be used by the ALB. | string | - | yes |
 | environment | Environment tag, e.g prod. | string | - | yes |
-| http_container_health_check_path | The destination for the health check requests to the HTTP container. | string | `/` | no |
-| http_container_port | The port on which the container will receive traffic. Set to 0 to disable http. | string | `80` | no |
-| http_container_protocol | The protocol to use to connect with the container. | string | `HTTP` | no |
-| http_container_success_codes | The HTTP codes to use when checking for a successful response from the HTTP container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | string | `200` | no |
 | https_container_health_check_path | The destination for the health check requests to the HTTPS container. | string | `/` | no |
-| https_container_port | The port on which the container will receive traffic. Set to 0 to disable https. | string | `443` | no |
+| https_container_port | The port on which the container will receive traffic. | string | `443` | no |
 | https_container_protocol | The protocol to use to connect with the container. | string | `HTTPS` | no |
 | https_container_success_codes | The HTTP codes to use when checking for a successful response from the HTTPS container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | string | `200` | no |
 | logs_s3_bucket | S3 bucket for storing Application Load Balancer logs. | string | - | yes |
@@ -50,7 +46,6 @@ module "app_alb" {
 |------|-------------|
 | alb_arn | The ARN of the ALB. |
 | alb_dns_name | DNS name of the ALB. |
-| alb_http_target_group_id | ID of the target group with the HTTP listener. |
 | alb_https_listener_arn | The ARN associated with the HTTPS listener on the ALB. |
 | alb_https_target_group_id | ID of the target group with the HTTPS listener. |
 | alb_security_group_id | Security Group ID assigned to the ALB. |

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ module "app_alb" {
 | alb_certificate_arn | The ARN of the certificate to be attached to the ALB. | string | - | yes |
 | alb_subnet_ids | Subnets IDs for the ALB. | list | - | yes |
 | alb_vpc_id | VPC ID to be used by the ALB. | string | - | yes |
+| container_port | The port on which the container will receive traffic. | string | `443` | no |
+| container_protocol | The protocol to use to connect with the container. | string | `HTTPS` | no |
 | environment | Environment tag, e.g prod. | string | - | yes |
-| https_container_health_check_path | The destination for the health check requests to the HTTPS container. | string | `/` | no |
-| https_container_port | The port on which the container will receive traffic. | string | `443` | no |
-| https_container_protocol | The protocol to use to connect with the container. | string | `HTTPS` | no |
-| https_container_success_codes | The HTTP codes to use when checking for a successful response from the HTTPS container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | string | `200` | no |
+| health_check_path | The destination for the health check requests to the container. | string | `/` | no |
+| health_check_success_codes | The HTTP codes to use when checking for a successful response from the container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | string | `200` | no |
 | logs_s3_bucket | S3 bucket for storing Application Load Balancer logs. | string | - | yes |
 | name | The service name. | string | - | yes |
 
@@ -46,9 +46,9 @@ module "app_alb" {
 |------|-------------|
 | alb_arn | The ARN of the ALB. |
 | alb_dns_name | DNS name of the ALB. |
-| alb_https_listener_arn | The ARN associated with the HTTPS listener on the ALB. |
-| alb_https_target_group_id | ID of the target group with the HTTPS listener. |
+| alb_listener_arn | The ARN associated with the HTTPS listener on the ALB. |
 | alb_security_group_id | Security Group ID assigned to the ALB. |
+| alb_target_group_id | ID of the target group with the HTTPS listener. |
 | alb_zone_id | Route53 hosted zone ID associated with the ALB. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "aws_security_group_rule" "app_alb_allow_http_from_world" {
 # ALB
 #
 
-resource "aws_alb" "main" {
+resource "aws_lb" "main" {
   name            = "${var.name}-${var.environment}"
   subnets         = ["${var.alb_subnet_ids}"]
   security_groups = ["${aws_security_group.alb_sg.id}"]
@@ -95,7 +95,7 @@ resource "aws_alb" "main" {
   }
 }
 
-resource "aws_alb_target_group" "https" {
+resource "aws_lb_target_group" "https" {
   name        = "ecs-${var.name}-${var.environment}-https"
   port        = "${var.container_port}"
   protocol    = "${var.container_protocol}"
@@ -113,7 +113,7 @@ resource "aws_alb_target_group" "https" {
   }
 
   # Ensure the ALB exists before things start referencing this target group.
-  depends_on = ["aws_alb.main"]
+  depends_on = ["aws_lb.main"]
 
   tags = {
     Environment = "${var.environment}"
@@ -121,20 +121,20 @@ resource "aws_alb_target_group" "https" {
   }
 }
 
-resource "aws_alb_listener" "https" {
-  load_balancer_arn = "${aws_alb.main.id}"
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = "${aws_lb.main.id}"
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = "${var.alb_certificate_arn}"
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.https.id}"
+    target_group_arn = "${aws_lb_target_group.https.id}"
     type             = "forward"
   }
 }
 
-resource "aws_alb_listener" "http" {
-  load_balancer_arn = "${aws_alb.main.id}"
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = "${aws_lb.main.id}"
   port              = "80"
   protocol          = "HTTP"
 

--- a/main.tf
+++ b/main.tf
@@ -97,8 +97,8 @@ resource "aws_alb" "main" {
 
 resource "aws_alb_target_group" "https" {
   name        = "ecs-${var.name}-${var.environment}-https"
-  port        = "${var.https_container_port}"
-  protocol    = "${var.https_container_protocol}"
+  port        = "${var.container_port}"
+  protocol    = "${var.container_protocol}"
   vpc_id      = "${var.alb_vpc_id}"
   target_type = "ip"
 
@@ -107,9 +107,9 @@ resource "aws_alb_target_group" "https" {
   deregistration_delay = 90
 
   health_check {
-    path     = "${var.https_container_health_check_path}"
-    protocol = "${var.https_container_protocol}"
-    matcher  = "${var.https_container_success_codes}"
+    path     = "${var.health_check_path}"
+    protocol = "${var.container_protocol}"
+    matcher  = "${var.health_check_success_codes}"
   }
 
   # Ensure the ALB exists before things start referencing this target group.

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,25 +5,25 @@ output "alb_security_group_id" {
 
 output "alb_target_group_id" {
   description = "ID of the target group with the HTTPS listener."
-  value       = "${aws_alb_target_group.https.id}"
+  value       = "${aws_lb_target_group.https.id}"
 }
 
 output "alb_arn" {
   description = "The ARN of the ALB."
-  value       = "${aws_alb.main.arn}"
+  value       = "${aws_lb.main.arn}"
 }
 
 output "alb_dns_name" {
   description = "DNS name of the ALB."
-  value       = "${aws_alb.main.dns_name}"
+  value       = "${aws_lb.main.dns_name}"
 }
 
 output "alb_listener_arn" {
   description = "The ARN associated with the HTTPS listener on the ALB."
-  value       = "${aws_alb_listener.https.arn}"
+  value       = "${aws_lb_listener.https.arn}"
 }
 
 output "alb_zone_id" {
   description = "Route53 hosted zone ID associated with the ALB."
-  value       = "${aws_alb.main.zone_id}"
+  value       = "${aws_lb.main.zone_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,7 @@ output "alb_security_group_id" {
 
 output "alb_https_target_group_id" {
   description = "ID of the target group with the HTTPS listener."
-  value       = "${join("", aws_alb_target_group.https.*.id)}"
-}
-
-output "alb_http_target_group_id" {
-  description = "ID of the target group with the HTTP listener."
-  value       = "${join("", aws_alb_target_group.http.*.id)}"
+  value       = "${aws_alb_target_group.https.id}"
 }
 
 output "alb_arn" {
@@ -25,7 +20,7 @@ output "alb_dns_name" {
 
 output "alb_https_listener_arn" {
   description = "The ARN associated with the HTTPS listener on the ALB."
-  value       = "${join("", aws_alb_listener.https.*.arn)}"
+  value       = "${aws_alb_listener.https.arn}"
 }
 
 output "alb_zone_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "alb_security_group_id" {
   value       = "${aws_security_group.alb_sg.id}"
 }
 
-output "alb_https_target_group_id" {
+output "alb_target_group_id" {
   description = "ID of the target group with the HTTPS listener."
   value       = "${aws_alb_target_group.https.id}"
 }
@@ -18,7 +18,7 @@ output "alb_dns_name" {
   value       = "${aws_alb.main.dns_name}"
 }
 
-output "alb_https_listener_arn" {
+output "alb_listener_arn" {
   description = "The ARN associated with the HTTPS listener on the ALB."
   value       = "${aws_alb_listener.https.arn}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,22 +28,10 @@ variable "alb_subnet_ids" {
   type        = "list"
 }
 
-variable "http_container_health_check_path" {
-  description = "The destination for the health check requests to the HTTP container."
-  type        = "string"
-  default     = "/"
-}
-
 variable "https_container_health_check_path" {
   description = "The destination for the health check requests to the HTTPS container."
   type        = "string"
   default     = "/"
-}
-
-variable "http_container_success_codes" {
-  description = "The HTTP codes to use when checking for a successful response from the HTTP container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299')."
-  type        = "string"
-  default     = "200"
 }
 
 variable "https_container_success_codes" {
@@ -52,30 +40,14 @@ variable "https_container_success_codes" {
   default     = "200"
 }
 
-variable "http_container_port" {
-  description = "The port on which the container will receive traffic. Set to 0 to disable http."
-  type        = "string"
-
-  default = 80
-}
-
-variable "http_container_protocol" {
-  description = "The protocol to use to connect with the container."
-  type        = "string"
-
-  default = "HTTP"
-}
-
 variable "https_container_port" {
-  description = "The port on which the container will receive traffic. Set to 0 to disable https."
+  description = "The port on which the container will receive traffic."
   type        = "string"
-
-  default = 443
+  default     = 443
 }
 
 variable "https_container_protocol" {
   description = "The protocol to use to connect with the container."
   type        = "string"
-
-  default = "HTTPS"
+  default     = "HTTPS"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,25 +28,25 @@ variable "alb_subnet_ids" {
   type        = "list"
 }
 
-variable "https_container_health_check_path" {
-  description = "The destination for the health check requests to the HTTPS container."
+variable "health_check_path" {
+  description = "The destination for the health check requests to the container."
   type        = "string"
   default     = "/"
 }
 
-variable "https_container_success_codes" {
-  description = "The HTTP codes to use when checking for a successful response from the HTTPS container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299')."
+variable "health_check_success_codes" {
+  description = "The HTTP codes to use when checking for a successful response from the container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299')."
   type        = "string"
   default     = "200"
 }
 
-variable "https_container_port" {
+variable "container_port" {
   description = "The port on which the container will receive traffic."
   type        = "string"
   default     = 443
 }
 
-variable "https_container_protocol" {
+variable "container_protocol" {
   description = "The protocol to use to connect with the container."
   type        = "string"
   default     = "HTTPS"


### PR DESCRIPTION
_This will be tagged as v2.0.0._

This is a significant change to this module. It completely drops support for an HTTP container and instead automatically configures the port 80 listener to redirect to 443.

Additionally the following changes were made:
* Simplified the variables and outputs names since we no longer need to differentiate between http and https container options.
* Migrated to the `aws_lb` resources instead of using the older `aws_alb` ones.

This PR is broken into 3 commits which accomplish each of those things independently.