### PR TITLE
Toggle security group rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.7.3
+    rev: v1.7.4
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ module "app_alb" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb\_certificate\_arns | The ARNs of the certificates to be attached to the ALB. | list | `<list>` | no |
+| alb\_certificate\_arns | The ARNs of the certificates to be attached to the ALB. | list | `[]` | no |
 | alb\_default\_certificate\_arn | The ARN of the default certificate to be attached to the ALB. | string | - | yes |
 | alb\_internal | If true, the ALB will be internal. | string | `false` | no |
 | alb\_ssl\_policy | The SSL policy (aka security policy) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies>. | string | `ELBSecurityPolicy-2016-08` | no |
 | alb\_subnet\_ids | Subnet IDs for the ALB. | list | - | yes |
 | alb\_vpc\_id | VPC ID to be used by the ALB. | string | - | yes |
+| allow\_public\_http | Allow inbound access from the Internet to port 80 | string | `true` | no |
+| allow\_public\_https | Allow inbound access from the Internet to port 443 | string | `true` | no |
 | container\_port | The port on which the container will receive traffic. | string | `443` | no |
 | container\_protocol | The protocol to use to connect with the container. | string | `HTTPS` | no |
 | deregistration\_delay | The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s. | string | `90` | no |

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,8 @@ resource "aws_security_group_rule" "app_alb_allow_outbound" {
 }
 
 resource "aws_security_group_rule" "app_alb_allow_https_from_world" {
+  count = "${var.allow_public_https}"
+
   description       = "Allow in HTTPS"
   security_group_id = "${aws_security_group.alb_sg.id}"
 
@@ -70,6 +72,8 @@ resource "aws_security_group_rule" "app_alb_allow_https_from_world" {
 }
 
 resource "aws_security_group_rule" "app_alb_allow_http_from_world" {
+  count = "${var.allow_public_http}"
+
   description       = "Allow in HTTP"
   security_group_id = "${aws_security_group.alb_sg.id}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,15 @@ variable "container_protocol" {
   type        = "string"
   default     = "HTTPS"
 }
+
+variable "allow_public_http" {
+  description = "Allow inbound access from the Internet to port 80"
+  type        = "string"
+  default     = true
+}
+
+variable "allow_public_https" {
+  description = "Allow inbound access from the Internet to port 443"
+  type        = "string"
+  default     = true
+}


### PR DESCRIPTION
This PR adds the `allow_public_http` and `allow_public_https` variables, which are off by default.  This allows us to manage security group rules for access to the ALB in other modules, as we're doing for honeycomb.  This does change the default behavior, so I could be convinced to toggle the security group rules on by default.