### PR TITLE
Export all alb attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: trussworks/circleci-docker-primary:d0dd0a134c842e234d1df641884a2b6036def4a4
+      - image: trussworks/circleci-docker-primary:a18ba9987556eec2e48354848a3c9fb4d5b69ac8
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.2.3
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.15.0
+    rev: v0.17.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ module "app_alb" {
 | Name | Description |
 |------|-------------|
 | alb\_arn | The ARN of the ALB. |
+| alb\_arn\_suffix | The ARN Suffix of the ALB for use with CloudWatch Metrics. |
 | alb\_dns\_name | DNS name of the ALB. |
+| alb\_id | The ID of the ALB. |
 | alb\_listener\_arn | The ARN associated with the HTTPS listener on the ALB. |
 | alb\_security\_group\_id | Security Group ID assigned to the ALB. |
 | alb\_target\_group\_id | ID of the target group with the HTTPS listener. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,19 @@ output "alb_target_group_id" {
   value       = "${aws_lb_target_group.https.id}"
 }
 
+output "alb_id" {
+  description = "The ID of the ALB."
+  value       = "${aws_lb.main.id}"
+}
+
 output "alb_arn" {
   description = "The ARN of the ALB."
   value       = "${aws_lb.main.arn}"
+}
+
+output "alb_arn_suffix" {
+  description = "The ARN Suffix of the ALB for use with CloudWatch Metrics."
+  value       = "${aws_lb.main.arn_suffix}"
 }
 
 output "alb_dns_name" {
@@ -18,12 +28,12 @@ output "alb_dns_name" {
   value       = "${aws_lb.main.dns_name}"
 }
 
-output "alb_listener_arn" {
-  description = "The ARN associated with the HTTPS listener on the ALB."
-  value       = "${aws_lb_listener.https.arn}"
-}
-
 output "alb_zone_id" {
   description = "Route53 hosted zone ID associated with the ALB."
   value       = "${aws_lb.main.zone_id}"
+}
+
+output "alb_listener_arn" {
+  description = "The ARN associated with the HTTPS listener on the ALB."
+  value       = "${aws_lb_listener.https.arn}"
 }


### PR DESCRIPTION
To support cloudwatch metric dashboards I need to expose the ALB suffix. I decided to also export the ID while I was here since its the only un-exported ALB attribute.

Previously we had to write: 

```
LoadBalancer = "app/${basename(dirname(module.alb_web_containers.alb_arn))}/${basename(module.alb_web_containers.alb_arn)}"
```

Now we can write:

```
LoadBalancer = "${module.alb_web_containers.alb_arn_suffix}"
```