### PR TITLE
Fixes to support terraform-docs 0.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-4d635dae28eaccd4486a91b93ae57d35f73de536
+      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
     steps:
       - checkout
       - restore_cache:

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "no-inline-html": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.21.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.21.0
+    rev: v1.24.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.21.0
+    rev: v1.23.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -36,32 +36,38 @@ module "app_alb" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alb\_certificate\_arns | The ARNs of the certificates to be attached to the ALB. | list(string) | `[]` | no |
-| alb\_default\_certificate\_arn | The ARN of the default certificate to be attached to the ALB. | string | n/a | yes |
-| alb\_idle\_timeout | The time in seconds that the connection is allowed to be idle. | number | `"60"` | no |
-| alb\_internal | If true, the ALB will be internal. Default's to false, the ALB will be public. | string | `"false"` | no |
-| alb\_ssl\_policy | The SSL policy \(aka security policy\) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies>. | string | `"ELBSecurityPolicy-2016-08"` | no |
-| alb\_subnet\_ids | Subnet IDs for the ALB. Use public subnets for a public ALB and private subnets for an internal ALB. | list(string) | n/a | yes |
-| alb\_vpc\_id | VPC ID to be used by the ALB. | string | n/a | yes |
-| allow\_public\_http | Allow inbound access from the Internet to port 80 | string | `"true"` | no |
-| allow\_public\_https | Allow inbound access from the Internet to port 443 | string | `"true"` | no |
-| container\_port | The port on which the container will receive traffic. | string | `"443"` | no |
-| container\_protocol | The protocol to use to connect with the container. | string | `"HTTPS"` | no |
-| deregistration\_delay | The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s. | string | `"90"` | no |
-| environment | Environment tag, e.g prod. | string | n/a | yes |
-| health\_check\_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds. | string | `"30"` | no |
-| health\_check\_path | The destination for the health check requests to the container. | string | `"/"` | no |
-| health\_check\_success\_codes | The HTTP codes to use when checking for a successful response from the container. You can specify multiple values \(for example, '200,202'\) or a range of values \(for example, '200-299'\). | string | `"200"` | no |
-| health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | string | `"5"` | no |
-| healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | string | `"3"` | no |
-| logs\_s3\_bucket | S3 bucket for storing Application Load Balancer logs. | string | n/a | yes |
-| name | The service name. | string | n/a | yes |
-| target\_group\_name | Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: ecs-\[name\]-\[environment\]-\[protocol\]. | string | `""` | no |
-| unhealthy\_threshold | The number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the healthy\_threshold. Defaults to 3. | string | `"3"` | no |
+|------|-------------|------|---------|:-----:|
+| alb\_certificate\_arns | The ARNs of the certificates to be attached to the ALB. | `list(string)` | `[]` | no |
+| alb\_default\_certificate\_arn | The ARN of the default certificate to be attached to the ALB. | `string` | n/a | yes |
+| alb\_idle\_timeout | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
+| alb\_internal | If true, the ALB will be internal. Default's to false, the ALB will be public. | `string` | `false` | no |
+| alb\_ssl\_policy | The SSL policy (aka security policy) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies>. | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| alb\_subnet\_ids | Subnet IDs for the ALB. Use public subnets for a public ALB and private subnets for an internal ALB. | `list(string)` | n/a | yes |
+| alb\_vpc\_id | VPC ID to be used by the ALB. | `string` | n/a | yes |
+| allow\_public\_http | Allow inbound access from the Internet to port 80 | `string` | `true` | no |
+| allow\_public\_https | Allow inbound access from the Internet to port 443 | `string` | `true` | no |
+| container\_port | The port on which the container will receive traffic. | `string` | `443` | no |
+| container\_protocol | The protocol to use to connect with the container. | `string` | `"HTTPS"` | no |
+| deregistration\_delay | The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s. | `string` | `90` | no |
+| environment | Environment tag, e.g prod. | `string` | n/a | yes |
+| health\_check\_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds. | `string` | `30` | no |
+| health\_check\_path | The destination for the health check requests to the container. | `string` | `"/"` | no |
+| health\_check\_success\_codes | The HTTP codes to use when checking for a successful response from the container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | `string` | `"200"` | no |
+| health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
+| healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `string` | `3` | no |
+| logs\_s3\_bucket | S3 bucket for storing Application Load Balancer logs. | `string` | n/a | yes |
+| name | The service name. | `string` | n/a | yes |
+| target\_group\_name | Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[protocol]. | `string` | `""` | no |
+| unhealthy\_threshold | The number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the healthy\_threshold. Defaults to 3. | `string` | `3` | no |
 
 ## Outputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -24,9 +24,10 @@ module "alb" {
 
 module "logs" {
   source         = "trussworks/logs/aws"
-  version        = "~> 4"
+  version        = "~> 5"
   s3_bucket_name = var.logs_bucket
   region         = var.region
+  force_destroy  = true
 }
 
 module "acm-cert" {

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/test/terraform_aws_alb_web_containers_test.go
+++ b/test/terraform_aws_alb_web_containers_test.go
@@ -43,7 +43,6 @@ func TestTerraformAwsAlbWebContainersSimpleHttp(t *testing.T) {
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
-	defer aws.EmptyS3Bucket(t, awsRegion, loggingBucket)
 	terraform.InitAndApply(t, terraformOptions)
 
 	// Run `terraform output` to get the value of an output variable


### PR DESCRIPTION
terraform-docs 0.8 will dump some inline HTML in the readme for object variable, so I've removed the rule from the markdownlint config.

I've also updated the tests to use the force_destroy flag to fix intermittent test failures when the logs bucket fails to empty before Terratest triggers a terrafrom destroy.