### PR TITLE
Add second ALB target group and related outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,12 @@ module "app_alb" {
 | alb\_arn\_suffix | The ARN Suffix of the ALB for use with CloudWatch Metrics. |
 | alb\_dns\_name | DNS name of the ALB. |
 | alb\_id | The ID of the ALB. |
+| alb\_listener | The ALB HTTPS listener object |
 | alb\_listener\_arn | The ARN associated with the HTTPS listener on the ALB. |
+| alb\_security\_group | Security Group object assigned to the ALB. |
 | alb\_security\_group\_id | Security Group ID assigned to the ALB. |
+| alb\_target\_group | Object of the first target group with HTTPS listener |
+| alb\_target\_group\_2 | Object of the second target group with HTTPS listener |
 | alb\_target\_group\_id | ID of the target group with the HTTPS listener. |
 | alb\_zone\_id | Route53 hosted zone ID associated with the ALB. |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,27 @@
+output "alb_security_group" {
+  description = "Security Group object assigned to the ALB."
+  value       = aws_security_group.alb_sg
+}
+
 output "alb_security_group_id" {
   description = "Security Group ID assigned to the ALB."
   value       = aws_security_group.alb_sg.id
 }
 
+output "alb_target_group" {
+  description = "Object of the first target group with HTTPS listener"
+  value       = aws_lb_target_group.https
+}
+
 output "alb_target_group_id" {
   description = "ID of the target group with the HTTPS listener."
   value       = aws_lb_target_group.https.id
+}
+
+
+output "alb_target_group_2" {
+  description = "Object of the second target group with HTTPS listener"
+  value       = aws_lb_target_group.https2
 }
 
 output "alb_id" {
@@ -31,6 +47,11 @@ output "alb_dns_name" {
 output "alb_zone_id" {
   description = "Route53 hosted zone ID associated with the ALB."
   value       = aws_lb.main.zone_id
+}
+
+output "alb_listener" {
+  description = "The ALB HTTPS listener object"
+  value       = aws_lb_listener.https
 }
 
 output "alb_listener_arn" {


### PR DESCRIPTION
This PR adds a second ALB target group to be used with blue/green deployments. Also added are related outputs.