### PR TITLE
Add slow start and load balancer algorithm variables to target group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.37.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ module "app_alb" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.13 |
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Inputs
 
@@ -73,8 +73,10 @@ module "app_alb" {
 | health\_check\_success\_codes | The HTTP codes to use when checking for a successful response from the container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | `string` | `"200"` | no |
 | health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
 | healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `string` | `3` | no |
+| load\_balancing\_algorithm\_type | Determines how the load balancer selects targets when routing requests.  Default is round\_robin. | `string` | `"round_robin"` | no |
 | logs\_s3\_bucket | S3 bucket for storing Application Load Balancer logs. | `string` | n/a | yes |
 | name | The service name. | `string` | n/a | yes |
+| slow\_start | The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0. | `number` | `0` | no |
 | target\_group\_name | Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[protocol]. | `string` | `""` | no |
 | unhealthy\_threshold | The number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the healthy\_threshold. Defaults to 3. | `string` | `3` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,9 @@ resource "aws_lb_target_group" "https" {
 
   # The amount time for the LB to wait before changing the state of a
   # deregistering target from draining to unused. AWS default is 300 seconds.
-  deregistration_delay = var.deregistration_delay
+  deregistration_delay          = var.deregistration_delay
+  slow_start                    = var.slow_start
+  load_balancing_algorithm_type = var.load_balancing_algorithm_type
 
   health_check {
     timeout             = var.health_check_timeout
@@ -140,4 +142,3 @@ resource "aws_lb_listener_certificate" "main" {
   listener_arn    = aws_lb_listener.https.arn
   certificate_arn = element(var.alb_certificate_arns, count.index)
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,18 @@ variable "deregistration_delay" {
   default     = 90
 }
 
+variable "load_balancing_algorithm_type" {
+  description = "Determines how the load balancer selects targets when routing requests.  Default is round_robin."
+  type        = string
+  default     = "round_robin"
+}
+
+variable "slow_start" {
+  description = "The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0."
+  type        = number
+  default     = 0
+}
+
 variable "health_check_interval" {
   description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds."
   type        = string


### PR DESCRIPTION
Adds `slow_start` and `load_balancer_algorithm_type` variables, with AWS defaults used, to the LB target group