### PR TITLE
Relax AWS provider version to permit use of 3.x with TF0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.33.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ module "app_alb" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = ">= 2.70, < 4.0"
   }
 }


### PR DESCRIPTION
This PR relaxes the version constraints for the AWS provider to permit the Terraform 0.12 branch to use AWS provider 3.x in addition to the previously permitted 2.70+ - the existing constraint is unnecessarily restrictive.

I had a bit of grief regenerating/updating the README.md using terraform-docs, the sections outside of the PRE-COMMIT-HOOK comments/markers were being stripped off, so I ended up updating it by hand - this is a yak I don't have the time to shave at the moment I'm afraid.