### PR TITLE
Support optional access logs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.35.2
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ module "app_alb" {
 | health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
 | healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `string` | `3` | no |
 | load\_balancing\_algorithm\_type | Determines how the load balancer selects targets when routing requests.  Default is round\_robin. | `string` | `"round_robin"` | no |
-| logs\_s3\_bucket | S3 bucket for storing Application Load Balancer logs. | `string` | n/a | yes |
+| logs\_s3\_bucket | S3 bucket for storing access logs. Set to empty string to disable logs. | `string` | n/a | yes |
 | name | The service name. | `string` | n/a | yes |
 | slow\_start | The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0. | `number` | `0` | no |
 | target\_group\_name | Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[protocol]. | `string` | `""` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,7 +11,7 @@ module "alb" {
 
   name           = var.test_name
   environment    = local.environment
-  logs_s3_bucket = module.logs.aws_logs_bucket
+  logs_s3_bucket = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
 
   alb_vpc_id                  = module.vpc.vpc_id
   alb_subnet_ids              = module.vpc.public_subnets
@@ -23,6 +23,7 @@ module "alb" {
 }
 
 module "logs" {
+  count          = var.logs_bucket == "" ? 0 : 1
   source         = "trussworks/logs/aws"
   version        = "~> 10"
   s3_bucket_name = var.logs_bucket

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_lb" "main" {
   idle_timeout    = var.alb_idle_timeout
 
   access_logs {
-    enabled = true
+    enabled = var.logs_s3_bucket == "" ? false : true
     bucket  = var.logs_s3_bucket
     prefix  = "alb/${var.name}-${var.environment}"
   }

--- a/main.tf
+++ b/main.tf
@@ -62,10 +62,14 @@ resource "aws_lb" "main" {
   security_groups = [aws_security_group.alb_sg.id]
   idle_timeout    = var.alb_idle_timeout
 
-  access_logs {
-    enabled = var.logs_s3_bucket == "" ? false : true
-    bucket  = var.logs_s3_bucket
-    prefix  = "alb/${var.name}-${var.environment}"
+  dynamic "access_logs" {
+    # Skips creating the block if logs_s3_bucket is empty string
+    for_each = var.logs_s3_bucket == "" ? [] : ["create block"]
+    content {
+      enabled = true
+      bucket  = var.logs_s3_bucket
+      prefix  = "alb/${var.name}-${var.environment}"
+    }
   }
 
   tags = {

--- a/test/terraform_aws_alb_web_containers_test.go
+++ b/test/terraform_aws_alb_web_containers_test.go
@@ -14,7 +14,7 @@ import (
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
-func TestTerraformAwsAlbWebContainersSimpleHttp(t *testing.T) {
+func TestTerraformAwsAlbWebContainersSimpleHttpWithLogging(t *testing.T) {
 	t.Parallel()
 
 	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
@@ -32,6 +32,69 @@ func TestTerraformAwsAlbWebContainersSimpleHttp(t *testing.T) {
 		Vars: map[string]interface{}{
 			"test_name":   testName,
 			"logs_bucket": loggingBucket,
+			"vpc_azs":     vpcAzs,
+			"region":      awsRegion,
+		},
+
+		// Environment variables to set when running Terraform
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply`
+	_, err := terraform.InitAndApplyE(t, terraformOptions)
+
+	/*
+		We need to apply twice because of the current bug with `dynamic` blocks in terraform `aws` provider:
+		Error: Provider produced inconsistent final plan
+
+		When expanding the plan for module.alb.aws_lb.main to include new values
+		learned so far during apply, provider "registry.terraform.io/hashicorp/aws"
+		produced an invalid new value for .access_logs[0].bucket: was
+		cty.StringVal(""), but now cty.StringVal("terratest-rbbbb7-logs").
+
+		This is a bug in the provider, which should be reported in the provider's own
+		issue tracker.
+		https://github.com/terraform-providers/terraform-provider-aws/issues/10297
+		https://github.com/terraform-providers/terraform-provider-aws/issues/7987
+		https://github.com/hashicorp/terraform/issues/20517
+	*/
+	if err != nil {
+		terraform.Apply(t, terraformOptions)
+	}
+
+	// Run `terraform output` to get the value of an output variable
+	dnsEndpoint := terraform.Output(t, terraformOptions, "dns_endpoint")
+	testURL := fmt.Sprintf("https://%s/", dnsEndpoint)
+	expectedText := "Hello, world!"
+	tlsConfig := tls.Config{}
+
+	maxRetries := 10
+	timeBetweenRetries := 10 * time.Second
+
+	http_helper.HttpGetWithRetry(t, testURL, &tlsConfig, 200, expectedText, maxRetries, timeBetweenRetries)
+}
+
+func TestTerraformAwsAlbWebContainersSimpleHttpWithoutLogging(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
+
+	testName := fmt.Sprintf("terratest-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+	vpcAzs := aws.GetAvailabilityZones(t, awsRegion)[:3]
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"test_name":   testName,
+			"logs_bucket": "",
 			"vpc_azs":     vpcAzs,
 			"region":      awsRegion,
 		},

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 }
 
 variable "logs_s3_bucket" {
-  description = "S3 bucket for storing Application Load Balancer logs."
+  description = "S3 bucket for storing access logs. Set to empty string to disable logs."
   type        = string
 }
 


### PR DESCRIPTION
This came up while I was drafting what a Hello, World project might look like. I don't want the student to have to create an S3 bucket + policy just to bring up an ALB. This felt like a simple change that doesn't impact the default of logging.