### PR TITLE
uncomment gosec and upgraded go to 1.16

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters:
     enable:
-    #   - gosec
+       - gosec
        - golint
        - gofmt
        - goimports

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/trussworks/terraform-aws-alb-web-containers
 
-go 1.13
+go 1.15
 
 require github.com/gruntwork-io/terratest v0.32.21

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/trussworks/terraform-aws-alb-web-containers
 
-go 1.15
+go 1.16
 
 require github.com/gruntwork-io/terratest v0.32.21

--- a/test/terraform_aws_alb_web_containers_test.go
+++ b/test/terraform_aws_alb_web_containers_test.go
@@ -49,8 +49,9 @@ func TestTerraformAwsAlbWebContainersSimpleHttp(t *testing.T) {
 	dnsEndpoint := terraform.Output(t, terraformOptions, "dns_endpoint")
 	testURL := fmt.Sprintf("https://%s/", dnsEndpoint)
 	expectedText := "Hello, world!"
-	tlsConfig := tls.Config{}
-
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	maxRetries := 10
 	timeBetweenRetries := 10 * time.Second
 


### PR DESCRIPTION
[Tracker Story](https://www.pivotaltracker.com/story/show/174868687)

- updated go version 
- un-comment -gosec
- made updated terratest by adding Minimum TLS version of 1.2
 - I looked and I don't believe AWS supports TLS13 I would need a verify  