### PR TITLE
Support optional access logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:c3e7af3280d4a0f9788459db82493da7a1d5046f
+      image: trussworks/circleci:caa7ee5c649b541f3fde6473d32b045bcfdb93ef
     steps:
     - checkout
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:56d41758666174506ef9a98769e448c63acc2045
+      image: trussworks/circleci:c3e7af3280d4a0f9788459db82493da7a1d5046f
     steps:
     - checkout
     - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.27.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.50.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.41.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "app_alb" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
@@ -90,7 +90,7 @@ No modules.
 | <a name="input_health_check_timeout"></a> [health\_check\_timeout](#input\_health\_check\_timeout) | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
 | <a name="input_healthy_threshold"></a> [healthy\_threshold](#input\_healthy\_threshold) | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `string` | `3` | no |
 | <a name="input_load_balancing_algorithm_type"></a> [load\_balancing\_algorithm\_type](#input\_load\_balancing\_algorithm\_type) | Determines how the load balancer selects targets when routing requests.  Default is round\_robin. | `string` | `"round_robin"` | no |
-| <a name="input_logs_s3_bucket"></a> [logs\_s3\_bucket](#input\_logs\_s3\_bucket) | S3 bucket for storing Application Load Balancer logs. | `string` | n/a | yes |
+| <a name="input_logs_s3_bucket"></a> [logs\_s3\_bucket](#input\_logs\_s3\_bucket) | S3 bucket for storing access logs. Set to empty string to disable logs. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The service name. | `string` | n/a | yes |
 | <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | A map of tags to add to the ALB's security group. | `map(string)` | `{}` | no |
 | <a name="input_slow_start"></a> [slow\_start](#input\_slow\_start) | The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0. | `number` | `0` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,7 +11,7 @@ module "alb" {
 
   name           = var.test_name
   environment    = local.environment
-  logs_s3_bucket = module.logs.aws_logs_bucket
+  logs_s3_bucket = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
 
   alb_vpc_id                  = module.vpc.vpc_id
   alb_subnet_ids              = module.vpc.public_subnets
@@ -23,6 +23,8 @@ module "alb" {
 }
 
 module "logs" {
+  count = var.logs_bucket == "" ? 0 : 1
+
   source         = "trussworks/logs/aws"
   version        = "~> 10"
   s3_bucket_name = var.logs_bucket

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_lb" "main" {
   idle_timeout    = var.alb_idle_timeout
 
   access_logs {
-    enabled = true
+    enabled = var.logs_s3_bucket == "" ? false : true
     bucket  = var.logs_s3_bucket
     prefix  = "alb/${var.name}-${var.environment}"
   }

--- a/main.tf
+++ b/main.tf
@@ -65,10 +65,14 @@ resource "aws_lb" "main" {
   security_groups = [aws_security_group.alb_sg.id]
   idle_timeout    = var.alb_idle_timeout
 
-  access_logs {
-    enabled = var.logs_s3_bucket == "" ? false : true
-    bucket  = var.logs_s3_bucket
-    prefix  = "alb/${var.name}-${var.environment}"
+  dynamic "access_logs" {
+    # Skips creating the block if logs_s3_bucket is empty string
+    for_each = var.logs_s3_bucket == "" ? [] : ["create block"]
+    content {
+      enabled = true
+      bucket  = var.logs_s3_bucket
+      prefix  = "alb/${var.name}-${var.environment}"
+    }
   }
 
   tags = {

--- a/test/terraform_aws_alb_web_containers_test.go
+++ b/test/terraform_aws_alb_web_containers_test.go
@@ -57,3 +57,46 @@ func TestTerraformAwsAlbWebContainersSimpleHttp(t *testing.T) {
 
 	http_helper.HttpGetWithRetry(t, testURL, &tlsConfig, 200, expectedText, maxRetries, timeBetweenRetries)
 }
+
+func TestTerraformAwsAlbWebContainersSimpleHttpDisabledLogs(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
+
+	testName := fmt.Sprintf("terratest-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+	vpcAzs := aws.GetAvailabilityZones(t, awsRegion)[:3]
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"test_name":   testName,
+			"logs_bucket": "", // this is the option being tested
+			"vpc_azs":     vpcAzs,
+			"region":      awsRegion,
+		},
+
+		// Environment variables to set when running Terraform
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	dnsEndpoint := terraform.Output(t, terraformOptions, "dns_endpoint")
+	testURL := fmt.Sprintf("https://%s/", dnsEndpoint)
+	expectedText := "Hello, world!"
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	maxRetries := 10
+	timeBetweenRetries := 10 * time.Second
+
+	http_helper.HttpGetWithRetry(t, testURL, &tlsConfig, 200, expectedText, maxRetries, timeBetweenRetries)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 }
 
 variable "logs_s3_bucket" {
-  description = "S3 bucket for storing Application Load Balancer logs."
+  description = "S3 bucket for storing access logs. Set to empty string to disable logs."
   type        = string
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15.2"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Makes it possible to create an ALB that doesn't log to S3. The default to log (because you should) remains. This change makes it easier to build stacks for teaching/learning where you want things fairly stripped down at the beginning.

This supersedes #85 (which I can not reopen due to the deletion of original branch it forked from). That old PR eventually got closed due to a bug in Terraform we were hitting that was fixed in hashicorp/terraform#28424.