### PR TITLE
Optionally pass an already existing SG to the ALB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,8 @@
 #
 
 resource "aws_security_group" "alb_sg" {
+  count = var.security_group == "" ? 1 : 0
+
   name        = "alb-${var.name}-${var.environment}"
   description = "${var.name}-${var.environment} ALB security group"
   vpc_id      = var.alb_vpc_id
@@ -17,9 +19,15 @@ resource "aws_security_group" "alb_sg" {
   )
 }
 
+locals {
+  security_group = "${var.security_group == "" ? aws_security_group.alb_sg[0].id : var.security_group}"
+}
+
 resource "aws_security_group_rule" "app_alb_allow_outbound" {
+  count = var.security_group == "" ? 1 : 0
+
   description       = "All outbound"
-  security_group_id = aws_security_group.alb_sg.id
+  security_group_id = aws_security_group.alb_sg[0].id
 
   type        = "egress"
   from_port   = 0
@@ -29,10 +37,10 @@ resource "aws_security_group_rule" "app_alb_allow_outbound" {
 }
 
 resource "aws_security_group_rule" "app_alb_allow_https_from_world" {
-  count = var.allow_public_https ? 1 : 0
+  count = var.security_group == "" && var.allow_public_https ? 1 : 0
 
   description       = "Allow in HTTPS"
-  security_group_id = aws_security_group.alb_sg.id
+  security_group_id = aws_security_group.alb_sg[0].id
 
   type        = "ingress"
   from_port   = 443
@@ -42,10 +50,10 @@ resource "aws_security_group_rule" "app_alb_allow_https_from_world" {
 }
 
 resource "aws_security_group_rule" "app_alb_allow_http_from_world" {
-  count = var.allow_public_http ? 1 : 0
+  count = var.security_group == "" && var.allow_public_http ? 1 : 0
 
   description       = "Allow in HTTP"
-  security_group_id = aws_security_group.alb_sg.id
+  security_group_id = aws_security_group.alb_sg[0].id
 
   type        = "ingress"
   from_port   = 80
@@ -62,7 +70,7 @@ resource "aws_lb" "main" {
   name            = "${var.name}-${var.environment}"
   internal        = var.alb_internal
   subnets         = var.alb_subnet_ids
-  security_groups = [aws_security_group.alb_sg.id]
+  security_groups = [local.security_group]
   idle_timeout    = var.alb_idle_timeout
 
   dynamic "access_logs" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "alb_security_group_id" {
   description = "Security Group ID assigned to the ALB."
-  value       = aws_security_group.alb_sg.id
+  value       = local.security_group
 }
 
 output "alb_target_group_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,9 @@ variable "security_group_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "security_group" {
+  description = "SG for the ALB"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Useful if you are using this module to deploy an ECS service using 2 ALBs; one for public traffic and another one for private traffic