### PR TITLE
ci: removing pr limit in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,6 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Removing PR limit for renovate to allow it to create as many PRs as it needs to.
