### PR TITLE
deprecate older terraform versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ The HTTP listener redirects to HTTPS.
 
 The HTTPS listener uses a certificate stored in ACM or IAM.
 
-## Terraform Versions
-
-Terraform 0.13. Pin module version to ~> 5.X. Submit pull-requests to master branch.
-
-Terraform 0.12. Pin module version to ~> 4.X. Submit pull-requests to terraform012 branch.
-
 ## Usage
 
 ```hcl

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.2"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## [Deprecate support for ancient terraform versions in our modules](https://trello.com/c/H27opwG6)

- Modified README
- Set expected terraform version to be equal or greater than Terraform version 1.0