### PR TITLE
feat: Add in desync_mitigation and protocol version to module variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ No modules.
 | allow\_public\_https | Allow inbound access from the Internet to port 443 | `string` | `true` | no |
 | container\_port | The port on which the container will receive traffic. | `string` | `443` | no |
 | container\_protocol | The protocol to use to connect with the container. | `string` | `"HTTPS"` | no |
+| container\_protocol\_version | The protocol version to use with the container. | `string` | `"HTTP1"` | no |
 | deregistration\_delay | The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s. | `string` | `90` | no |
+| desync\_mitigation\_mode | Specifies how the load balancer handles security issues related to HTTP desync | `string` | `"defensive"` | no |
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer | `string` | `false` | no |
 | environment | Environment tag, e.g prod. | `string` | n/a | yes |
 | health\_check\_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds. | `string` | `30` | no |

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,7 @@ resource "aws_lb" "main" {
   subnets         = var.alb_subnet_ids
   security_groups = [local.security_group]
   idle_timeout    = var.alb_idle_timeout
+  desync_mitigation_mode = var.desync_mitigation_mode
 
   enable_deletion_protection = var.enable_deletion_protection
 
@@ -88,6 +89,7 @@ resource "aws_lb_target_group" "https" {
   name        = coalesce(var.target_group_name, format("ecs-%s-%s-https", var.name, var.environment))
   port        = var.container_port
   protocol    = var.container_protocol
+  protocol_version = var.container_protocol_version
   vpc_id      = var.alb_vpc_id
   target_type = "ip"
 

--- a/main.tf
+++ b/main.tf
@@ -62,11 +62,11 @@ resource "aws_security_group_rule" "app_alb_allow_http_from_world" {
 #
 
 resource "aws_lb" "main" {
-  name            = "${var.name}-${var.environment}"
-  internal        = var.alb_internal
-  subnets         = var.alb_subnet_ids
-  security_groups = [local.security_group]
-  idle_timeout    = var.alb_idle_timeout
+  name                   = "${var.name}-${var.environment}"
+  internal               = var.alb_internal
+  subnets                = var.alb_subnet_ids
+  security_groups        = [local.security_group]
+  idle_timeout           = var.alb_idle_timeout
   desync_mitigation_mode = var.desync_mitigation_mode
 
   enable_deletion_protection = var.enable_deletion_protection
@@ -86,12 +86,12 @@ resource "aws_lb" "main" {
 resource "aws_lb_target_group" "https" {
   # Name must be less than or equal to 32 characters, or AWS API returns error.
   # Error: "name" cannot be longer than 32 characters
-  name        = coalesce(var.target_group_name, format("ecs-%s-%s-https", var.name, var.environment))
-  port        = var.container_port
-  protocol    = var.container_protocol
+  name             = coalesce(var.target_group_name, format("ecs-%s-%s-https", var.name, var.environment))
+  port             = var.container_port
+  protocol         = var.container_protocol
   protocol_version = var.container_protocol_version
-  vpc_id      = var.alb_vpc_id
-  target_type = "ip"
+  vpc_id           = var.alb_vpc_id
+  target_type      = "ip"
 
   # The amount time for the LB to wait before changing the state of a
   # deregistering target from draining to unused. AWS default is 300 seconds.

--- a/variables.tf
+++ b/variables.tf
@@ -63,8 +63,8 @@ variable "container_protocol" {
 
 variable "container_protocol_version" {
   description = "The protocol version to use with the container."
-  type = string
-  default = "HTTP1"
+  type        = string
+  default     = "HTTP1"
 }
 
 variable "deregistration_delay" {
@@ -75,8 +75,8 @@ variable "deregistration_delay" {
 
 variable "desync_mitigation_mode" {
   description = "Specifies how the load balancer handles security issues related to HTTP desync"
-  type = string
-  default = "defensive"
+  type        = string
+  default     = "defensive"
 }
 
 variable "enable_deletion_protection" {

--- a/variables.tf
+++ b/variables.tf
@@ -61,10 +61,22 @@ variable "container_protocol" {
   default     = "HTTPS"
 }
 
+variable "container_protocol_version" {
+  description = "The protocol version to use with the container."
+  type = string
+  default = "HTTP1"
+}
+
 variable "deregistration_delay" {
   description = "The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s."
   type        = string
   default     = 90
+}
+
+variable "desync_mitigation_mode" {
+  description = "Specifies how the load balancer handles security issues related to HTTP desync"
+  type = string
+  default = "defensive"
 }
 
 variable "enable_deletion_protection" {


### PR DESCRIPTION
Allowed users of the module to configure the desync_mitigation and protocol version values for the LB and target group respectively.
