### PR TITLE
feat: v10.1.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,13 +1,33 @@
-name: validate-tf
+name: Validate - Terraform
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   pull_request:
-    branches:
-      - main
+  push:
+    branches: [main]
 
 jobs:
   validate-tf:
-    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - name: Render terraform docs inside the README.md
+        uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25 # v1.3.0
+        with:
+          working-dir: .
+          config-file: .terraform-docs.yml
+          output-method: ""
+          output-file: ""
+          output-format: ""
+          template: ""
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.13"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        env:
+          SKIP: ${{ vars.SKIP }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.13"
+      - uses: terraform-linters/setup-tflint@8093687ecc9dcbfa88d07c103ad4176739a7287e # v4.1.0
+        with:
+          tflint_wrapper: true
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:
           SKIP: ${{ vars.SKIP }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,55 @@
+# Local .terraform directories
+**/.terraform/*
+.terraform/
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+*.envrc.local
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+.terraform.lock.hcl
+**/.terraform.lock.hcl
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+tfplan
+*.plan
+*.out
+
+#Editors
 .DS_Store
-.terraform
-terraform.tfstate
-terraform.tfstate.backup
-terraform.tfstate.*.backup
+*.swp
+*.sublime-*
+.*.stamp
+.idea
+.vscode/
+tmp/
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,8 @@
+default: true
+first-line-h1: false
+first-header-h1: false
+line_length: false
+no-multiple-blanks: false
+no-inline-html: false
+no-alt-text: false
+heading-increment: false

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,8 +1,0 @@
-{
-  "default": true,
-  "first-header-h1": false,
-  "first-line-h1": false,
-  "line_length": false,
-  "no-multiple-blanks": false,
-  "no-inline-html": false
-}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,67 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
-      - id: check-merge-conflict
+        name: "Check JSON"
       - id: check-yaml
-      - id: detect-private-key
+        name: "Check YAML"
+        args:
+          - --allow-multiple-documents
+      - id: check-merge-conflict
+        name: "Check Merge Conflicts"
       - id: pretty-format-json
+        name: "Pretty Format JSON"
         args:
           - --autofix
       - id: trailing-whitespace
-      - id: check-symlinks
+        name: "Trailing Whitespace"
+        args:
+          - --markdown-linebreak-ext=md
       - id: end-of-file-fixer
+        name: "EOF Fixer"
       - id: mixed-line-ending
+        name: "Mixed Line Ending"
+        args: ["--fix=no"]
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.31.1
     hooks:
-      - id: mdformat
-        additional_dependencies:
-          - mdformat-gfm
-          - mdformat-toc
-        # mdformat fights with terraform_docs
-        exclude: README.m(ark)?d(own)?
-
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
-    hooks:
-      - id: markdownlint
-
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
-    hooks:
-      - id: shell-lint
+      - id: check-renovate
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: "Validate Pre-Commit"
+        files: ^\.pre-commit-config.yaml+$
+        types:
+          - yaml
+        args: ["--schemafile", "schemas/pre-commit-config.json"]
+      - id: check-jsonschema
+        name: "Validate MarkdownLint"
+        files: ^\.markdownlint.yml+$
+        types:
+          - yaml
+        args: ["--schemafile", "schemas/markdownlint-config-schema.json"]
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.80.0
+    rev: v1.97.0
     hooks:
+      - id: terraform_validate
+        name: "Terraform Validate"
       - id: terraform_fmt
+        name: "Terraform Format"
+      - id: terraform_tflint
+        name: "Terraform Lint"
+        args:
+          - --args=--config=__GIT_WORKING_DIR__.tflint.hcl
+
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: v0.19.0
+    hooks:
+      - id: terraform-docs-system
+        name: "Terraform Docs"
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
+    hooks:
+      - id: markdownlint-cli2
+        name: "Markdown Lint"

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,50 @@
+formatter: "markdown table"
+
+version: ">= 0.19.0, < 1.0.0"
+
+recursive:
+  enabled: false
+  include-main: false
+
 settings:
   html: false
   anchor: false
-formatter: "markdown table"
+  escape: false
+  lockfile: false
+  hide-empty: true
+
+sort:
+  enabled: true
+  by: required
+
+sections:
+  show:
+    - providers
+    - requirements
+    - inputs
+    - outputs
+    - resources
+    - data-sources
+
+content: |-
+  ***
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Providers }}
+
+  {{ .Requirements }}
+
+  {{ .Resources }}
+
+  ***
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,33 @@
+plugin "terraform" {
+  enabled = true
+  version = "0.10.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+  preset  = "all"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.37.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+rule "aws_iam_policy_attachment_exclusive_attachment" {
+  enabled = true
+}
+
+config {
+  format = "compact"
+  call_module_type = "none"
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+}

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,2 @@
+misconfigurations:
+  - id: AVD-AWS-0053

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: target_lock
+target_lock:
+	terraform providers lock \
+  		-platform=windows_amd64 \
+  		-platform=darwin_amd64 \
+  		-platform=darwin_arm64 \
+  		-platform=linux_amd64
+
+.PHONY: check
+check:
+	tflint
+	terraform validate
+	trivy config .
+
+.PHONY: docs
+docs:
+	terraform-docs -c .terraform-docs.yml .

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ The HTTPS listener uses a certificate stored in ACM or IAM.
 module "app_alb" {
   source = "trussworks/alb-web-containers/aws"
 
-  name           = "app"
-  environment    = "prod"
-  logs_s3_bucket = "my-aws-logs"
+  name                   = "app"
+  environment            = "prod"
+  enable_access_logs     = true
+  enable_connection_logs = true
+  logs_s3_bucket         = "my-aws-logs"
 
-  alb_vpc_id                  = "${module.vpc.vpc_id}"
-  alb_subnet_ids              = "${module.vpc.public_subnets}"
-  alb_default_certificate_arn = "${aws_acm_certificate.cert.arn}"
+  alb_vpc_id                  = aws.vpc.vpc_id
+  alb_subnet_ids              = var.subnet_ids
+  alb_default_certificate_arn = aws_acm_certificate.cert.arn
 
   container_port    = "443"
   health_check_path = "/health"
@@ -30,22 +32,76 @@ module "app_alb" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+***
 
-| Name | Version |
-|------|---------|
-| terraform | >= 1.0 |
-| aws | >= 3.0 |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| alb_default_certificate_arn | The ARN of the default certificate to be attached to the ALB. | `string` | n/a | yes |
+| alb_subnet_ids | Subnet IDs for the ALB. Use public subnets for a public ALB and private subnets for an internal ALB. | `list(string)` | n/a | yes |
+| alb_vpc_id | VPC ID to be used by the ALB. | `string` | n/a | yes |
+| environment | Environment tag, e.g prod. | `string` | n/a | yes |
+| name | The service name. | `string` | n/a | yes |
+| additional_security_groups | A list of additional Security Groups to attach to the ALB. | `list(string)` | `null` | no |
+| alb_idle_timeout | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
+| alb_internal | If true, the ALB will be internal. Default's to false, the ALB will be public. | `string` | `false` | no |
+| alb_listener_certificate_arns | The ARNs of the additional certificates to be attached to the HTTPS Listener on the ALB. Does not replace the default certifcate on the listener. | `list(string)` | `[]` | no |
+| alb_ssl_policy | The SSL policy (aka security policy) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See [https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html) | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
+| allow_public_http | Allow inbound access from the Internet to port 80. | `string` | `true` | no |
+| allow_public_https | Allow inbound access from the Internet to port 443. | `string` | `true` | no |
+| container_port | The port on which the container will receive traffic. | `string` | `443` | no |
+| container_protocol | The protocol to use to connect with the container. | `string` | `"HTTPS"` | no |
+| container_protocol_version | The protocol version to use with the container. | `string` | `"HTTP1"` | no |
+| deregistration_delay | The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s. | `string` | `90` | no |
+| desync_mitigation_mode | How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are monitor, defensive (default), strictest. | `string` | `"defensive"` | no |
+| drop_invalid_header_fields | Whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is true. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. | `bool` | `true` | no |
+| enable_access_logs | Enable ALB Access Logs. | `bool` | `false` | no |
+| enable_connection_logs | Enable ALB Connection Logs. | `bool` | `false` | no |
+| enable_deletion_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancera. | `bool` | `false` | no |
+| enable_waf_fail_open | Whether to allow a WAF-enabled load balancer to route requests to targets if it is unable to forward the request to AWS WAF. Defaults to false. | `bool` | `false` | no |
+| health_check_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds. | `string` | `30` | no |
+| health_check_path | The destination for the health check requests to the container. | `string` | `"/"` | no |
+| health_check_success_codes | The HTTP codes to use when checking for a successful response from the container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | `string` | `"200"` | no |
+| health_check_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
+| healthy_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `string` | `3` | no |
+| load_balancing_algorithm_type | Determines how the load balancer selects targets when routing requests.  Default is round_robin. | `string` | `"round_robin"` | no |
+| logs_s3_bucket | S3 bucket for storing access logs. | `string` | `null` | no |
+| logs_s3_prefix | Overrides prefix for ALB logs | `string` | `""` | no |
+| logs_s3_prefix_enabled | Toggle for ALB logs S3 prefix | `bool` | `true` | no |
+| preserve_host_header | Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. | `bool` | `false` | no |
+| security_group | User-defined Security Group for the ALB. Defining a Security Group here will cause the module to not create a Security Group for the ALB. | `string` | `null` | no |
+| security_group_tags | A map of tags to add to the ALB's security group. | `map(string)` | `{}` | no |
+| slow_start | The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0. | `number` | `0` | no |
+| target_group_name | Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: `ecs-[name]-[environment]-HTTPS`. | `string` | `""` | no |
+| unhealthy_threshold | The number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the healthy_threshold. Defaults to 3. | `string` | `3` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| alb_arn | The ARN of the ALB. |
+| alb_arn_suffix | The ARN Suffix of the ALB for use with CloudWatch Metrics. |
+| alb_dns_name | DNS name of the ALB. |
+| alb_id | ARN of the load balancer (matches arn). |
+| alb_listener_arn | The ARN associated with the HTTPS listener on the ALB. |
+| alb_listener_arn_suffix | The ARN suffix associated with the HTTPS listener on the ALB for use with CloudWatch Metrics. |
+| alb_security_group_id | Security Group ID assigned to the ALB. |
+| alb_target_group_id | ID of the target group with the HTTPS listener. |
+| alb_zone_id | Canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record). |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| aws | ~> 5.0 |
 
-## Modules
+## Requirements
 
-No modules.
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| aws | ~> 5.0 |
 
 ## Resources
 
@@ -59,56 +115,9 @@ No modules.
 | [aws_security_group.alb_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.app_alb_allow_http_from_world](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.app_alb_allow_https_from_world](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.app_alb_allow_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.app_alb_allow_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_groupt_rule) | resource |
 
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| alb\_certificate\_arns | The ARNs of the certificates to be attached to the ALB. | `list(string)` | `[]` | no |
-| alb\_default\_certificate\_arn | The ARN of the default certificate to be attached to the ALB. | `string` | n/a | yes |
-| alb\_idle\_timeout | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
-| alb\_internal | If true, the ALB will be internal. Default's to false, the ALB will be public. | `string` | `false` | no |
-| alb\_ssl\_policy | The SSL policy (aka security policy) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies>. | `string` | `"ELBSecurityPolicy-2016-08"` | no |
-| alb\_subnet\_ids | Subnet IDs for the ALB. Use public subnets for a public ALB and private subnets for an internal ALB. | `list(string)` | n/a | yes |
-| alb\_vpc\_id | VPC ID to be used by the ALB. | `string` | n/a | yes |
-| allow\_public\_http | Allow inbound access from the Internet to port 80 | `string` | `true` | no |
-| allow\_public\_https | Allow inbound access from the Internet to port 443 | `string` | `true` | no |
-| container\_port | The port on which the container will receive traffic. | `string` | `443` | no |
-| container\_protocol | The protocol to use to connect with the container. | `string` | `"HTTPS"` | no |
-| container\_protocol\_version | The protocol version to use with the container. | `string` | `"HTTP1"` | no |
-| deregistration\_delay | The amount time for the LB to wait before changing the state of a deregistering target from draining to unused. Default is 90s. | `string` | `90` | no |
-| desync\_mitigation\_mode | Specifies how the load balancer handles security issues related to HTTP desync | `string` | `"defensive"` | no |
-| enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer | `string` | `false` | no |
-| environment | Environment tag, e.g prod. | `string` | n/a | yes |
-| health\_check\_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds. | `string` | `30` | no |
-| health\_check\_path | The destination for the health check requests to the container. | `string` | `"/"` | no |
-| health\_check\_success\_codes | The HTTP codes to use when checking for a successful response from the container. You can specify multiple values (for example, '200,202') or a range of values (for example, '200-299'). | `string` | `"200"` | no |
-| health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
-| healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3. | `string` | `3` | no |
-| load\_balancing\_algorithm\_type | Determines how the load balancer selects targets when routing requests.  Default is round\_robin. | `string` | `"round_robin"` | no |
-| logs\_s3\_bucket | S3 bucket for storing access logs. Set to empty string to disable logs. | `string` | n/a | yes |
-| logs\_s3\_prefix | Overrides prefix for ALB logs | `string` | `""` | no |
-| logs\_s3\_prefix\_enabled | Toggle for ALB logs S3 prefix | `bool` | `true` | no |
-| name | The service name. | `string` | n/a | yes |
-| security\_group | SG for the ALB | `string` | `""` | no |
-| security\_group\_tags | A map of tags to add to the ALB's security group. | `map(string)` | `{}` | no |
-| slow\_start | The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0. | `number` | `0` | no |
-| target\_group\_name | Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[protocol]. | `string` | `""` | no |
-| unhealthy\_threshold | The number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the healthy\_threshold. Defaults to 3. | `string` | `3` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| alb\_arn | The ARN of the ALB. |
-| alb\_arn\_suffix | The ARN Suffix of the ALB for use with CloudWatch Metrics. |
-| alb\_dns\_name | DNS name of the ALB. |
-| alb\_id | The ID of the ALB. |
-| alb\_listener\_arn | The ARN associated with the HTTPS listener on the ALB. |
-| alb\_security\_group\_id | Security Group ID assigned to the ALB. |
-| alb\_target\_group\_id | ID of the target group with the HTTPS listener. |
-| alb\_zone\_id | Route53 hosted zone ID associated with the ALB. |
+***
 <!-- END_TF_DOCS -->
 
 ## Developer Setup
@@ -116,6 +125,7 @@ No modules.
 Install dependencies (macOS)
 
 ```shell
-brew install pre-commit go terraform terraform-docs
+brew install pre-commit tfenv terraform-docs tflint trivy
+tfenv install
 pre-commit install --install-hooks
 ```

--- a/examples/s3-prefix-disabled/main.tf
+++ b/examples/s3-prefix-disabled/main.tf
@@ -11,12 +11,13 @@ module "alb" {
 
   name                   = var.test_name
   environment            = local.environment
+  enable_access_logs     = true
   logs_s3_bucket         = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
   logs_s3_prefix_enabled = false
 
   alb_vpc_id                  = module.vpc.vpc_id
   alb_subnet_ids              = module.vpc.public_subnets
-  alb_default_certificate_arn = module.acm-cert.acm_arn
+  alb_default_certificate_arn = module.acm_cert.acm_arn
 
   container_port     = local.container_port
   container_protocol = local.container_protocol
@@ -27,7 +28,8 @@ module "logs" {
   count = var.logs_bucket == "" ? 0 : 1
 
   source         = "trussworks/logs/aws"
-  version        = "~> 10"
+  version        = "~> 17"
+  allow_alb      = true
   s3_bucket_name = var.logs_bucket
   force_destroy  = true
   alb_logs_prefixes = [
@@ -35,13 +37,12 @@ module "logs" {
   ]
 }
 
-module "acm-cert" {
+module "acm_cert" {
   source  = "trussworks/acm-cert/aws"
-  version = "~> 3"
+  version = "~> 7"
 
   domain_name = "${var.test_name}.${local.zone_name}"
-  environment = local.environment
-  zone_name   = local.zone_name
+  zone_id     = data.aws_route53_zone.infra_truss_coffee.zone_id
 }
 
 data "aws_route53_zone" "infra_truss_coffee" {
@@ -58,16 +59,22 @@ resource "aws_route53_record" "main" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.64.0"
+  version = "~> 5"
 
-  name            = var.test_name
-  cidr            = "10.0.0.0/16"
-  azs             = var.vpc_azs
-  private_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-  public_subnets  = ["10.0.104.0/24", "10.0.105.0/24", "10.0.106.0/24"]
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_vpn_gateway = true
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
 }
 
 #
@@ -129,7 +136,7 @@ resource "aws_ecs_cluster" "main" {
   name = var.test_name
 }
 
-module "ecs-service" {
+module "ecs_service" {
   source  = "trussworks/ecs-service/aws"
   version = "~> 5"
 

--- a/examples/s3-prefix-disabled/outputs.tf
+++ b/examples/s3-prefix-disabled/outputs.tf
@@ -1,3 +1,4 @@
 output "dns_endpoint" {
-  value = "${var.test_name}.${local.zone_name}"
+  description = "DNS Endpoint"
+  value       = "${var.test_name}.${local.zone_name}"
 }

--- a/examples/s3-prefix-disabled/variables.tf
+++ b/examples/s3-prefix-disabled/variables.tf
@@ -1,15 +1,14 @@
 variable "logs_bucket" {
-  type = string
+  description = "S3 Log Bucket Name"
+  type        = string
 }
 
 variable "region" {
-  type = string
+  description = "AWS Region to provison resources"
+  type        = string
 }
 
 variable "test_name" {
-  type = string
-}
-
-variable "vpc_azs" {
-  type = list(string)
+  description = "App Name"
+  type        = string
 }

--- a/examples/s3-prefix/main.tf
+++ b/examples/s3-prefix/main.tf
@@ -9,14 +9,15 @@ locals {
 module "alb" {
   source = "../../"
 
-  name           = var.test_name
-  environment    = local.environment
-  logs_s3_bucket = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
-  logs_s3_prefix = var.logs_prefix
+  name                   = var.test_name
+  environment            = local.environment
+  enable_connection_logs = true
+  logs_s3_bucket         = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
+  logs_s3_prefix         = var.logs_prefix
 
   alb_vpc_id                  = module.vpc.vpc_id
   alb_subnet_ids              = module.vpc.public_subnets
-  alb_default_certificate_arn = module.acm-cert.acm_arn
+  alb_default_certificate_arn = module.acm_cert.acm_arn
 
   container_port     = local.container_port
   container_protocol = local.container_protocol
@@ -27,21 +28,21 @@ module "logs" {
   count = var.logs_bucket == "" ? 0 : 1
 
   source         = "trussworks/logs/aws"
-  version        = "~> 10"
+  version        = "~> 17"
   s3_bucket_name = var.logs_bucket
+  allow_alb      = true
   force_destroy  = true
   alb_logs_prefixes = [
     var.logs_prefix
   ]
 }
 
-module "acm-cert" {
+module "acm_cert" {
   source  = "trussworks/acm-cert/aws"
-  version = "~> 3"
+  version = "~> 7"
 
   domain_name = "${var.test_name}.${local.zone_name}"
-  environment = local.environment
-  zone_name   = local.zone_name
+  zone_id     = data.aws_route53_zone.infra_truss_coffee.zone_id
 }
 
 data "aws_route53_zone" "infra_truss_coffee" {
@@ -58,16 +59,22 @@ resource "aws_route53_record" "main" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.64.0"
+  version = "~> 5"
 
-  name            = var.test_name
-  cidr            = "10.0.0.0/16"
-  azs             = var.vpc_azs
-  private_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-  public_subnets  = ["10.0.104.0/24", "10.0.105.0/24", "10.0.106.0/24"]
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_vpn_gateway = true
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
 }
 
 #
@@ -129,7 +136,7 @@ resource "aws_ecs_cluster" "main" {
   name = var.test_name
 }
 
-module "ecs-service" {
+module "ecs_service" {
   source  = "trussworks/ecs-service/aws"
   version = "~> 5"
 

--- a/examples/s3-prefix/outputs.tf
+++ b/examples/s3-prefix/outputs.tf
@@ -1,3 +1,4 @@
 output "dns_endpoint" {
-  value = "${var.test_name}.${local.zone_name}"
+  description = "DNS Endpout"
+  value       = "${var.test_name}.${local.zone_name}"
 }

--- a/examples/s3-prefix/variables.tf
+++ b/examples/s3-prefix/variables.tf
@@ -1,19 +1,19 @@
 variable "logs_bucket" {
-  type = string
+  description = "S3 Log Bucket to Log to."
+  type        = string
 }
 
 variable "logs_prefix" {
-  type = string
+  description = "Prefix to attach to log ouptput. Typically 's3/<name>'."
+  type        = string
 }
 
 variable "region" {
-  type = string
+  description = "AWS Region"
+  type        = string
 }
 
 variable "test_name" {
-  type = string
-}
-
-variable "vpc_azs" {
-  type = list(string)
+  description = "App Name"
+  type        = string
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -9,13 +9,15 @@ locals {
 module "alb" {
   source = "../../"
 
-  name           = var.test_name
-  environment    = local.environment
-  logs_s3_bucket = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
+  name                   = var.test_name
+  environment            = local.environment
+  enable_access_logs     = true
+  enable_connection_logs = true
+  logs_s3_bucket         = var.logs_bucket == "" ? "" : module.logs[0].aws_logs_bucket
 
   alb_vpc_id                  = module.vpc.vpc_id
   alb_subnet_ids              = module.vpc.public_subnets
-  alb_default_certificate_arn = module.acm-cert.acm_arn
+  alb_default_certificate_arn = module.acm_cert.acm_arn
 
   container_port     = local.container_port
   container_protocol = local.container_protocol
@@ -26,21 +28,21 @@ module "logs" {
   count = var.logs_bucket == "" ? 0 : 1
 
   source         = "trussworks/logs/aws"
-  version        = "~> 10"
+  version        = "~> 17"
   s3_bucket_name = var.logs_bucket
+  allow_alb      = true
   force_destroy  = true
   alb_logs_prefixes = [
     "alb/${var.test_name}-${local.environment}"
   ]
 }
 
-module "acm-cert" {
+module "acm_cert" {
   source  = "trussworks/acm-cert/aws"
-  version = "~> 3"
+  version = "~> 7"
 
   domain_name = "${var.test_name}.${local.zone_name}"
-  environment = local.environment
-  zone_name   = local.zone_name
+  zone_id     = data.aws_route53_zone.infra_truss_coffee.zone_id
 }
 
 data "aws_route53_zone" "infra_truss_coffee" {
@@ -57,16 +59,22 @@ resource "aws_route53_record" "main" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.64.0"
+  version = "~> 5"
 
-  name            = var.test_name
-  cidr            = "10.0.0.0/16"
-  azs             = var.vpc_azs
-  private_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-  public_subnets  = ["10.0.104.0/24", "10.0.105.0/24", "10.0.106.0/24"]
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_vpn_gateway = true
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
 }
 
 #
@@ -128,9 +136,9 @@ resource "aws_ecs_cluster" "main" {
   name = var.test_name
 }
 
-module "ecs-service" {
+module "ecs_service" {
   source  = "trussworks/ecs-service/aws"
-  version = "~> 5"
+  version = "~> 7"
 
   name        = var.test_name
   environment = local.environment

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,3 +1,4 @@
 output "dns_endpoint" {
-  value = "${var.test_name}.${local.zone_name}"
+  description = "DNS Endpoint"
+  value       = "${var.test_name}.${local.zone_name}"
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -1,15 +1,14 @@
 variable "logs_bucket" {
-  type = string
+  description = "S3 Log Bucket Name"
+  type        = string
 }
 
 variable "region" {
-  type = string
+  description = "AWS Region to provison resources"
+  type        = string
 }
 
 variable "test_name" {
-  type = string
-}
-
-variable "vpc_azs" {
-  type = list(string)
+  description = "App Name"
+  type        = string
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 #
-# SG - ALB
+# Security Group - ALB
 #
 
 resource "aws_security_group" "alb_sg" {
-  count = var.security_group == "" ? 1 : 0
+  count = var.security_group == null ? 1 : 0
 
   name        = "alb-${var.name}-${var.environment}"
   description = "${var.name}-${var.environment} ALB security group"
@@ -15,7 +15,8 @@ resource "aws_security_group" "alb_sg" {
 }
 
 locals {
-  security_group = var.security_group == "" ? aws_security_group.alb_sg[0].id : var.security_group
+  security_group  = var.security_group == null ? [aws_security_group.alb_sg[0].id] : [var.security_group]
+  security_groups = var.additional_security_groups == null ? local.security_group : concat(var.additional_security_groups, local.security_group)
 }
 
 resource "aws_security_group_rule" "app_alb_allow_outbound" {
@@ -62,12 +63,15 @@ resource "aws_security_group_rule" "app_alb_allow_http_from_world" {
 #
 
 resource "aws_lb" "main" {
-  name                   = "${var.name}-${var.environment}"
-  internal               = var.alb_internal
-  subnets                = var.alb_subnet_ids
-  security_groups        = [local.security_group]
-  idle_timeout           = var.alb_idle_timeout
-  desync_mitigation_mode = var.desync_mitigation_mode
+  name                       = "${var.environment}-${var.name}"
+  drop_invalid_header_fields = var.drop_invalid_header_fields
+  enable_waf_fail_open       = var.enable_waf_fail_open
+  internal                   = var.alb_internal
+  preserve_host_header       = var.preserve_host_header
+  subnets                    = var.alb_subnet_ids
+  security_groups            = local.security_groups
+  idle_timeout               = var.alb_idle_timeout
+  desync_mitigation_mode     = var.desync_mitigation_mode
 
   enable_deletion_protection = var.enable_deletion_protection
 
@@ -75,7 +79,16 @@ resource "aws_lb" "main" {
     # Skips creating the block if logs_s3_bucket is empty string
     for_each = var.logs_s3_bucket == "" ? [] : ["create block"]
     content {
-      enabled = true
+      enabled = var.enable_access_logs
+      bucket  = var.logs_s3_bucket
+      prefix  = var.logs_s3_prefix_enabled == true ? (var.logs_s3_prefix == "" ? "alb/${var.name}-${var.environment}" : var.logs_s3_prefix) : ""
+    }
+  }
+
+  dynamic "connection_logs" {
+    for_each = var.logs_s3_bucket == "" ? [] : ["create block"]
+    content {
+      enabled = var.enable_connection_logs
       bucket  = var.logs_s3_bucket
       prefix  = var.logs_s3_prefix_enabled == true ? (var.logs_s3_prefix == "" ? "alb/${var.name}-${var.environment}" : var.logs_s3_prefix) : ""
     }
@@ -83,10 +96,14 @@ resource "aws_lb" "main" {
 
 }
 
+#
+# ALB Target Groups
+#
+
 resource "aws_lb_target_group" "https" {
   # Name must be less than or equal to 32 characters, or AWS API returns error.
   # Error: "name" cannot be longer than 32 characters
-  name             = coalesce(var.target_group_name, format("ecs-%s-%s-https", var.name, var.environment))
+  name             = coalesce(var.target_group_name, format("%s-%s-ecs-https", var.environment, var.name))
   port             = var.container_port
   protocol         = var.container_protocol
   protocol_version = var.container_protocol_version
@@ -113,6 +130,10 @@ resource "aws_lb_target_group" "https" {
   depends_on = [aws_lb.main]
 
 }
+
+#
+# ALB Listeners
+#
 
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.main.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,18 +1,3 @@
-output "alb_security_group_id" {
-  description = "Security Group ID assigned to the ALB."
-  value       = local.security_group
-}
-
-output "alb_target_group_id" {
-  description = "ID of the target group with the HTTPS listener."
-  value       = aws_lb_target_group.https.id
-}
-
-output "alb_id" {
-  description = "The ID of the ALB."
-  value       = aws_lb.main.id
-}
-
 output "alb_arn" {
   description = "The ARN of the ALB."
   value       = aws_lb.main.arn
@@ -28,12 +13,32 @@ output "alb_dns_name" {
   value       = aws_lb.main.dns_name
 }
 
-output "alb_zone_id" {
-  description = "Route53 hosted zone ID associated with the ALB."
-  value       = aws_lb.main.zone_id
+output "alb_id" {
+  description = "ARN of the load balancer (matches arn)."
+  value       = aws_lb.main.id
 }
 
 output "alb_listener_arn" {
   description = "The ARN associated with the HTTPS listener on the ALB."
   value       = aws_lb_listener.https.arn
+}
+
+output "alb_listener_arn_suffix" {
+  description = "The ARN suffix associated with the HTTPS listener on the ALB for use with CloudWatch Metrics."
+  value       = aws_lb_listener.https.arn
+}
+
+output "alb_security_group_id" {
+  description = "Security Group ID assigned to the ALB."
+  value       = local.security_group
+}
+
+output "alb_target_group_id" {
+  description = "ID of the target group with the HTTPS listener."
+  value       = aws_lb_target_group.https.id
+}
+
+output "alb_zone_id" {
+  description = "Canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record)."
+  value       = aws_lb.main.zone_id
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "config:base",
-    ":disableDependencyDashboard"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": [
     "dependencies"
@@ -9,47 +9,25 @@
   "packageRules": [
     {
       "automerge": true,
-      "description": "Automerge all updates except major versions",
-      "matchUpdateTypes": [
-        "patch",
-        "pin",
-        "digest",
-        "minor"
-      ]
-    },
-    {
-      "description": "Tag the waddlers Github Team for major updates",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "reviewers": [
-        "team:waddlers"
-      ]
-    },
-    {
-      "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-      "managers": [
+      "matchManagers": [
         "terraform",
-        "gomod",
         "pre-commit",
-        "circleci",
-        "dockerfile",
         "github-actions"
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "pin",
+        "digest"
       ]
     }
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
   ],
   "schedule": [
     "every weekend"
   ],
   "separateMinorPatch": true,
-  "timezone": "America/Los_Angeles"
+  "separateMultipleMajor": true,
+  "separateMultipleMinor": true
 }

--- a/schemas/markdownlint-config-schema.json
+++ b/schemas/markdownlint-config-schema.json
@@ -1,0 +1,1846 @@
+{
+  "$id": "https://raw.githubusercontent.com/DavidAnson/markdownlint/v0.37.4/schema/markdownlint-config-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": {
+    "type": [
+      "boolean",
+      "object"
+    ]
+  },
+  "properties": {
+    "$schema": {
+      "default": "https://raw.githubusercontent.com/DavidAnson/markdownlint/v0.37.4/schema/markdownlint-config-schema.json",
+      "description": "JSON Schema URI (expected by some editors)",
+      "type": "string"
+    },
+    "MD001": {
+      "default": true,
+      "description": "MD001/heading-increment : Heading levels should only increment by one level at a time : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md001.md",
+      "type": "boolean"
+    },
+    "MD003": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD003/heading-style : Heading style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md003.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Heading style",
+          "enum": [
+            "consistent",
+            "atx",
+            "atx_closed",
+            "setext",
+            "setext_with_atx",
+            "setext_with_atx_closed"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD004": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD004/ul-style : Unordered list style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md004.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "List style",
+          "enum": [
+            "consistent",
+            "asterisk",
+            "plus",
+            "dash",
+            "sublist"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD005": {
+      "default": true,
+      "description": "MD005/list-indent : Inconsistent indentation for list items at the same level : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md005.md",
+      "type": "boolean"
+    },
+    "MD007": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD007/ul-indent : Unordered list indentation : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md007.md",
+      "properties": {
+        "indent": {
+          "default": 2,
+          "description": "Spaces for indent",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "start_indent": {
+          "default": 2,
+          "description": "Spaces for first level indent (when start_indented is set)",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "start_indented": {
+          "default": false,
+          "description": "Whether to indent the first level of the list",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD009": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD009/no-trailing-spaces : Trailing spaces : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md009.md",
+      "properties": {
+        "br_spaces": {
+          "default": 2,
+          "description": "Spaces for line break",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "list_item_empty_lines": {
+          "default": false,
+          "description": "Allow spaces for empty lines in list items",
+          "type": "boolean"
+        },
+        "strict": {
+          "default": false,
+          "description": "Include unnecessary breaks",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD010": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD010/no-hard-tabs : Hard tabs : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md010.md",
+      "properties": {
+        "code_blocks": {
+          "default": true,
+          "description": "Include code blocks",
+          "type": "boolean"
+        },
+        "ignore_code_languages": {
+          "default": [],
+          "description": "Fenced code languages to ignore",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "spaces_per_tab": {
+          "default": 1,
+          "description": "Number of spaces for each hard tab",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD011": {
+      "default": true,
+      "description": "MD011/no-reversed-links : Reversed link syntax : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md011.md",
+      "type": "boolean"
+    },
+    "MD012": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD012/no-multiple-blanks : Multiple consecutive blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md012.md",
+      "properties": {
+        "maximum": {
+          "default": 1,
+          "description": "Consecutive blank lines",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD013": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md013.md",
+      "properties": {
+        "code_block_line_length": {
+          "default": 80,
+          "description": "Number of characters for code blocks",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "code_blocks": {
+          "default": true,
+          "description": "Include code blocks",
+          "type": "boolean"
+        },
+        "heading_line_length": {
+          "default": 80,
+          "description": "Number of characters for headings",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "headings": {
+          "default": true,
+          "description": "Include headings",
+          "type": "boolean"
+        },
+        "line_length": {
+          "default": 80,
+          "description": "Number of characters",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "stern": {
+          "default": false,
+          "description": "Stern length checking",
+          "type": "boolean"
+        },
+        "strict": {
+          "default": false,
+          "description": "Strict length checking",
+          "type": "boolean"
+        },
+        "tables": {
+          "default": true,
+          "description": "Include tables",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD014": {
+      "default": true,
+      "description": "MD014/commands-show-output : Dollar signs used before commands without showing output : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md014.md",
+      "type": "boolean"
+    },
+    "MD018": {
+      "default": true,
+      "description": "MD018/no-missing-space-atx : No space after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md018.md",
+      "type": "boolean"
+    },
+    "MD019": {
+      "default": true,
+      "description": "MD019/no-multiple-space-atx : Multiple spaces after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md019.md",
+      "type": "boolean"
+    },
+    "MD020": {
+      "default": true,
+      "description": "MD020/no-missing-space-closed-atx : No space inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md020.md",
+      "type": "boolean"
+    },
+    "MD021": {
+      "default": true,
+      "description": "MD021/no-multiple-space-closed-atx : Multiple spaces inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md021.md",
+      "type": "boolean"
+    },
+    "MD022": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD022/blanks-around-headings : Headings should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md022.md",
+      "properties": {
+        "lines_above": {
+          "default": 1,
+          "description": "Blank lines above heading",
+          "items": {
+            "type": "integer"
+          },
+          "minimum": -1,
+          "type": [
+            "integer",
+            "array"
+          ]
+        },
+        "lines_below": {
+          "default": 1,
+          "description": "Blank lines below heading",
+          "items": {
+            "type": "integer"
+          },
+          "minimum": -1,
+          "type": [
+            "integer",
+            "array"
+          ]
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD023": {
+      "default": true,
+      "description": "MD023/heading-start-left : Headings must start at the beginning of the line : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md023.md",
+      "type": "boolean"
+    },
+    "MD024": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md024.md",
+      "properties": {
+        "siblings_only": {
+          "default": false,
+          "description": "Only check sibling headings",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD025": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md025.md",
+      "properties": {
+        "front_matter_title": {
+          "default": "^\\s*title\\s*[:=]",
+          "description": "RegExp for matching title in front matter",
+          "type": "string"
+        },
+        "level": {
+          "default": 1,
+          "description": "Heading level",
+          "maximum": 6,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD026": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD026/no-trailing-punctuation : Trailing punctuation in heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md026.md",
+      "properties": {
+        "punctuation": {
+          "default": ".,;:!\u3002\uff0c\uff1b\uff1a\uff01",
+          "description": "Punctuation characters",
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD027": {
+      "default": true,
+      "description": "MD027/no-multiple-space-blockquote : Multiple spaces after blockquote symbol : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md027.md",
+      "type": "boolean"
+    },
+    "MD028": {
+      "default": true,
+      "description": "MD028/no-blanks-blockquote : Blank line inside blockquote : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md028.md",
+      "type": "boolean"
+    },
+    "MD029": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD029/ol-prefix : Ordered list item prefix : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md029.md",
+      "properties": {
+        "style": {
+          "default": "one_or_ordered",
+          "description": "List style",
+          "enum": [
+            "one",
+            "ordered",
+            "one_or_ordered",
+            "zero"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD030": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD030/list-marker-space : Spaces after list markers : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md030.md",
+      "properties": {
+        "ol_multi": {
+          "default": 1,
+          "description": "Spaces for multi-line ordered list items",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ol_single": {
+          "default": 1,
+          "description": "Spaces for single-line ordered list items",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ul_multi": {
+          "default": 1,
+          "description": "Spaces for multi-line unordered list items",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ul_single": {
+          "default": 1,
+          "description": "Spaces for single-line unordered list items",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD031": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md031.md",
+      "properties": {
+        "list_items": {
+          "default": true,
+          "description": "Include list items",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD032": {
+      "default": true,
+      "description": "MD032/blanks-around-lists : Lists should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md032.md",
+      "type": "boolean"
+    },
+    "MD033": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md033.md",
+      "properties": {
+        "allowed_elements": {
+          "default": [],
+          "description": "Allowed elements",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD034": {
+      "default": true,
+      "description": "MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md034.md",
+      "type": "boolean"
+    },
+    "MD035": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD035/hr-style : Horizontal rule style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md035.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Horizontal rule style",
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD036": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD036/no-emphasis-as-heading : Emphasis used instead of a heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md036.md",
+      "properties": {
+        "punctuation": {
+          "default": ".,;:!?\u3002\uff0c\uff1b\uff1a\uff01\uff1f",
+          "description": "Punctuation characters",
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD037": {
+      "default": true,
+      "description": "MD037/no-space-in-emphasis : Spaces inside emphasis markers : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md037.md",
+      "type": "boolean"
+    },
+    "MD038": {
+      "default": true,
+      "description": "MD038/no-space-in-code : Spaces inside code span elements : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md038.md",
+      "type": "boolean"
+    },
+    "MD039": {
+      "default": true,
+      "description": "MD039/no-space-in-links : Spaces inside link text : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md039.md",
+      "type": "boolean"
+    },
+    "MD040": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md040.md",
+      "properties": {
+        "allowed_languages": {
+          "default": [],
+          "description": "List of languages",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "language_only": {
+          "default": false,
+          "description": "Require language only",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD041": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md041.md",
+      "properties": {
+        "front_matter_title": {
+          "default": "^\\s*title\\s*[:=]",
+          "description": "RegExp for matching title in front matter",
+          "type": "string"
+        },
+        "level": {
+          "default": 1,
+          "description": "Heading level",
+          "maximum": 6,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD042": {
+      "default": true,
+      "description": "MD042/no-empty-links : No empty links : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md042.md",
+      "type": "boolean"
+    },
+    "MD043": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD043/required-headings : Required heading structure : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md043.md",
+      "properties": {
+        "headings": {
+          "default": [],
+          "description": "List of headings",
+          "items": {
+            "pattern": "^(\\*|\\+|#{1,6} .*)$",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "match_case": {
+          "default": false,
+          "description": "Match case of headings",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD044": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD044/proper-names : Proper names should have the correct capitalization : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md044.md",
+      "properties": {
+        "code_blocks": {
+          "default": true,
+          "description": "Include code blocks",
+          "type": "boolean"
+        },
+        "html_elements": {
+          "default": true,
+          "description": "Include HTML elements",
+          "type": "boolean"
+        },
+        "names": {
+          "default": [],
+          "description": "List of proper names",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD045": {
+      "default": true,
+      "description": "MD045/no-alt-text : Images should have alternate text (alt text) : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md045.md",
+      "type": "boolean"
+    },
+    "MD046": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD046/code-block-style : Code block style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md046.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Block style",
+          "enum": [
+            "consistent",
+            "fenced",
+            "indented"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD047": {
+      "default": true,
+      "description": "MD047/single-trailing-newline : Files should end with a single newline character : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md047.md",
+      "type": "boolean"
+    },
+    "MD048": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD048/code-fence-style : Code fence style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md048.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Code fence style",
+          "enum": [
+            "consistent",
+            "backtick",
+            "tilde"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD049": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD049/emphasis-style : Emphasis style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md049.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Emphasis style",
+          "enum": [
+            "consistent",
+            "asterisk",
+            "underscore"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD050": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD050/strong-style : Strong style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md050.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Strong style",
+          "enum": [
+            "consistent",
+            "asterisk",
+            "underscore"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD051": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD051/link-fragments : Link fragments should be valid : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md051.md",
+      "properties": {
+        "ignore_case": {
+          "default": false,
+          "description": "Ignore case of fragments",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD052": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD052/reference-links-images : Reference links and images should use a label that is defined : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md052.md",
+      "properties": {
+        "shortcut_syntax": {
+          "default": false,
+          "description": "Include shortcut syntax",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD053": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD053/link-image-reference-definitions : Link and image reference definitions should be needed : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md053.md",
+      "properties": {
+        "ignored_definitions": {
+          "default": [
+            "//"
+          ],
+          "description": "Ignored definitions",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD054": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD054/link-image-style : Link and image style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md054.md",
+      "properties": {
+        "autolink": {
+          "default": true,
+          "description": "Allow autolinks",
+          "type": "boolean"
+        },
+        "collapsed": {
+          "default": true,
+          "description": "Allow collapsed reference links and images",
+          "type": "boolean"
+        },
+        "full": {
+          "default": true,
+          "description": "Allow full reference links and images",
+          "type": "boolean"
+        },
+        "inline": {
+          "default": true,
+          "description": "Allow inline links and images",
+          "type": "boolean"
+        },
+        "shortcut": {
+          "default": true,
+          "description": "Allow shortcut reference links and images",
+          "type": "boolean"
+        },
+        "url_inline": {
+          "default": true,
+          "description": "Allow URLs as inline links",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD055": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD055/table-pipe-style : Table pipe style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md055.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Table pipe style",
+          "enum": [
+            "consistent",
+            "leading_only",
+            "trailing_only",
+            "leading_and_trailing",
+            "no_leading_or_trailing"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "MD056": {
+      "default": true,
+      "description": "MD056/table-column-count : Table column count : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md056.md",
+      "type": "boolean"
+    },
+    "MD058": {
+      "default": true,
+      "description": "MD058/blanks-around-tables : Tables should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md058.md",
+      "type": "boolean"
+    },
+    "accessibility": {
+      "default": true,
+      "description": "accessibility : MD045",
+      "type": "boolean"
+    },
+    "atx": {
+      "default": true,
+      "description": "atx : MD018, MD019",
+      "type": "boolean"
+    },
+    "atx_closed": {
+      "default": true,
+      "description": "atx_closed : MD020, MD021",
+      "type": "boolean"
+    },
+    "blank_lines": {
+      "default": true,
+      "description": "blank_lines : MD012, MD022, MD031, MD032, MD047",
+      "type": "boolean"
+    },
+    "blanks-around-fences": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md031.md",
+      "properties": {
+        "list_items": {
+          "default": true,
+          "description": "Include list items",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "blanks-around-headings": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD022/blanks-around-headings : Headings should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md022.md",
+      "properties": {
+        "lines_above": {
+          "default": 1,
+          "description": "Blank lines above heading",
+          "items": {
+            "type": "integer"
+          },
+          "minimum": -1,
+          "type": [
+            "integer",
+            "array"
+          ]
+        },
+        "lines_below": {
+          "default": 1,
+          "description": "Blank lines below heading",
+          "items": {
+            "type": "integer"
+          },
+          "minimum": -1,
+          "type": [
+            "integer",
+            "array"
+          ]
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "blanks-around-lists": {
+      "default": true,
+      "description": "MD032/blanks-around-lists : Lists should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md032.md",
+      "type": "boolean"
+    },
+    "blanks-around-tables": {
+      "default": true,
+      "description": "MD058/blanks-around-tables : Tables should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md058.md",
+      "type": "boolean"
+    },
+    "blockquote": {
+      "default": true,
+      "description": "blockquote : MD027, MD028",
+      "type": "boolean"
+    },
+    "bullet": {
+      "default": true,
+      "description": "bullet : MD004, MD005, MD007, MD032",
+      "type": "boolean"
+    },
+    "code": {
+      "default": true,
+      "description": "code : MD014, MD031, MD038, MD040, MD046, MD048",
+      "type": "boolean"
+    },
+    "code-block-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD046/code-block-style : Code block style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md046.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Block style",
+          "enum": [
+            "consistent",
+            "fenced",
+            "indented"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "code-fence-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD048/code-fence-style : Code fence style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md048.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Code fence style",
+          "enum": [
+            "consistent",
+            "backtick",
+            "tilde"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "commands-show-output": {
+      "default": true,
+      "description": "MD014/commands-show-output : Dollar signs used before commands without showing output : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md014.md",
+      "type": "boolean"
+    },
+    "default": {
+      "default": true,
+      "description": "Default state for all rules",
+      "type": "boolean"
+    },
+    "emphasis": {
+      "default": true,
+      "description": "emphasis : MD036, MD037, MD049, MD050",
+      "type": "boolean"
+    },
+    "emphasis-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD049/emphasis-style : Emphasis style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md049.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Emphasis style",
+          "enum": [
+            "consistent",
+            "asterisk",
+            "underscore"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "extends": {
+      "default": null,
+      "description": "Path to configuration file to extend",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "fenced-code-language": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md040.md",
+      "properties": {
+        "allowed_languages": {
+          "default": [],
+          "description": "List of languages",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "language_only": {
+          "default": false,
+          "description": "Require language only",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "first-line-h1": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md041.md",
+      "properties": {
+        "front_matter_title": {
+          "default": "^\\s*title\\s*[:=]",
+          "description": "RegExp for matching title in front matter",
+          "type": "string"
+        },
+        "level": {
+          "default": 1,
+          "description": "Heading level",
+          "maximum": 6,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "first-line-heading": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md041.md",
+      "properties": {
+        "front_matter_title": {
+          "default": "^\\s*title\\s*[:=]",
+          "description": "RegExp for matching title in front matter",
+          "type": "string"
+        },
+        "level": {
+          "default": 1,
+          "description": "Heading level",
+          "maximum": 6,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "hard_tab": {
+      "default": true,
+      "description": "hard_tab : MD010",
+      "type": "boolean"
+    },
+    "heading-increment": {
+      "default": true,
+      "description": "MD001/heading-increment : Heading levels should only increment by one level at a time : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md001.md",
+      "type": "boolean"
+    },
+    "heading-start-left": {
+      "default": true,
+      "description": "MD023/heading-start-left : Headings must start at the beginning of the line : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md023.md",
+      "type": "boolean"
+    },
+    "heading-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD003/heading-style : Heading style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md003.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Heading style",
+          "enum": [
+            "consistent",
+            "atx",
+            "atx_closed",
+            "setext",
+            "setext_with_atx",
+            "setext_with_atx_closed"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "headings": {
+      "default": true,
+      "description": "headings : MD001, MD003, MD018, MD019, MD020, MD021, MD022, MD023, MD024, MD025, MD026, MD036, MD041, MD043",
+      "type": "boolean"
+    },
+    "hr": {
+      "default": true,
+      "description": "hr : MD035",
+      "type": "boolean"
+    },
+    "hr-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD035/hr-style : Horizontal rule style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md035.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Horizontal rule style",
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "html": {
+      "default": true,
+      "description": "html : MD033",
+      "type": "boolean"
+    },
+    "images": {
+      "default": true,
+      "description": "images : MD045, MD052, MD053, MD054",
+      "type": "boolean"
+    },
+    "indentation": {
+      "default": true,
+      "description": "indentation : MD005, MD007, MD027",
+      "type": "boolean"
+    },
+    "language": {
+      "default": true,
+      "description": "language : MD040",
+      "type": "boolean"
+    },
+    "line-length": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md013.md",
+      "properties": {
+        "code_block_line_length": {
+          "default": 80,
+          "description": "Number of characters for code blocks",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "code_blocks": {
+          "default": true,
+          "description": "Include code blocks",
+          "type": "boolean"
+        },
+        "heading_line_length": {
+          "default": 80,
+          "description": "Number of characters for headings",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "headings": {
+          "default": true,
+          "description": "Include headings",
+          "type": "boolean"
+        },
+        "line_length": {
+          "default": 80,
+          "description": "Number of characters",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "stern": {
+          "default": false,
+          "description": "Stern length checking",
+          "type": "boolean"
+        },
+        "strict": {
+          "default": false,
+          "description": "Strict length checking",
+          "type": "boolean"
+        },
+        "tables": {
+          "default": true,
+          "description": "Include tables",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "line_length": {
+      "default": true,
+      "description": "line_length : MD013",
+      "type": "boolean"
+    },
+    "link-fragments": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD051/link-fragments : Link fragments should be valid : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md051.md",
+      "properties": {
+        "ignore_case": {
+          "default": false,
+          "description": "Ignore case of fragments",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "link-image-reference-definitions": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD053/link-image-reference-definitions : Link and image reference definitions should be needed : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md053.md",
+      "properties": {
+        "ignored_definitions": {
+          "default": [
+            "//"
+          ],
+          "description": "Ignored definitions",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "link-image-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD054/link-image-style : Link and image style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md054.md",
+      "properties": {
+        "autolink": {
+          "default": true,
+          "description": "Allow autolinks",
+          "type": "boolean"
+        },
+        "collapsed": {
+          "default": true,
+          "description": "Allow collapsed reference links and images",
+          "type": "boolean"
+        },
+        "full": {
+          "default": true,
+          "description": "Allow full reference links and images",
+          "type": "boolean"
+        },
+        "inline": {
+          "default": true,
+          "description": "Allow inline links and images",
+          "type": "boolean"
+        },
+        "shortcut": {
+          "default": true,
+          "description": "Allow shortcut reference links and images",
+          "type": "boolean"
+        },
+        "url_inline": {
+          "default": true,
+          "description": "Allow URLs as inline links",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "links": {
+      "default": true,
+      "description": "links : MD011, MD034, MD039, MD042, MD051, MD052, MD053, MD054",
+      "type": "boolean"
+    },
+    "list-indent": {
+      "default": true,
+      "description": "MD005/list-indent : Inconsistent indentation for list items at the same level : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md005.md",
+      "type": "boolean"
+    },
+    "list-marker-space": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD030/list-marker-space : Spaces after list markers : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md030.md",
+      "properties": {
+        "ol_multi": {
+          "default": 1,
+          "description": "Spaces for multi-line ordered list items",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ol_single": {
+          "default": 1,
+          "description": "Spaces for single-line ordered list items",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ul_multi": {
+          "default": 1,
+          "description": "Spaces for multi-line unordered list items",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ul_single": {
+          "default": 1,
+          "description": "Spaces for single-line unordered list items",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-alt-text": {
+      "default": true,
+      "description": "MD045/no-alt-text : Images should have alternate text (alt text) : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md045.md",
+      "type": "boolean"
+    },
+    "no-bare-urls": {
+      "default": true,
+      "description": "MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md034.md",
+      "type": "boolean"
+    },
+    "no-blanks-blockquote": {
+      "default": true,
+      "description": "MD028/no-blanks-blockquote : Blank line inside blockquote : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md028.md",
+      "type": "boolean"
+    },
+    "no-duplicate-heading": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md024.md",
+      "properties": {
+        "siblings_only": {
+          "default": false,
+          "description": "Only check sibling headings",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-emphasis-as-heading": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD036/no-emphasis-as-heading : Emphasis used instead of a heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md036.md",
+      "properties": {
+        "punctuation": {
+          "default": ".,;:!?\u3002\uff0c\uff1b\uff1a\uff01\uff1f",
+          "description": "Punctuation characters",
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-empty-links": {
+      "default": true,
+      "description": "MD042/no-empty-links : No empty links : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md042.md",
+      "type": "boolean"
+    },
+    "no-hard-tabs": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD010/no-hard-tabs : Hard tabs : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md010.md",
+      "properties": {
+        "code_blocks": {
+          "default": true,
+          "description": "Include code blocks",
+          "type": "boolean"
+        },
+        "ignore_code_languages": {
+          "default": [],
+          "description": "Fenced code languages to ignore",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "spaces_per_tab": {
+          "default": 1,
+          "description": "Number of spaces for each hard tab",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-inline-html": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md033.md",
+      "properties": {
+        "allowed_elements": {
+          "default": [],
+          "description": "Allowed elements",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-missing-space-atx": {
+      "default": true,
+      "description": "MD018/no-missing-space-atx : No space after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md018.md",
+      "type": "boolean"
+    },
+    "no-missing-space-closed-atx": {
+      "default": true,
+      "description": "MD020/no-missing-space-closed-atx : No space inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md020.md",
+      "type": "boolean"
+    },
+    "no-multiple-blanks": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD012/no-multiple-blanks : Multiple consecutive blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md012.md",
+      "properties": {
+        "maximum": {
+          "default": 1,
+          "description": "Consecutive blank lines",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-multiple-space-atx": {
+      "default": true,
+      "description": "MD019/no-multiple-space-atx : Multiple spaces after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md019.md",
+      "type": "boolean"
+    },
+    "no-multiple-space-blockquote": {
+      "default": true,
+      "description": "MD027/no-multiple-space-blockquote : Multiple spaces after blockquote symbol : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md027.md",
+      "type": "boolean"
+    },
+    "no-multiple-space-closed-atx": {
+      "default": true,
+      "description": "MD021/no-multiple-space-closed-atx : Multiple spaces inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md021.md",
+      "type": "boolean"
+    },
+    "no-reversed-links": {
+      "default": true,
+      "description": "MD011/no-reversed-links : Reversed link syntax : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md011.md",
+      "type": "boolean"
+    },
+    "no-space-in-code": {
+      "default": true,
+      "description": "MD038/no-space-in-code : Spaces inside code span elements : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md038.md",
+      "type": "boolean"
+    },
+    "no-space-in-emphasis": {
+      "default": true,
+      "description": "MD037/no-space-in-emphasis : Spaces inside emphasis markers : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md037.md",
+      "type": "boolean"
+    },
+    "no-space-in-links": {
+      "default": true,
+      "description": "MD039/no-space-in-links : Spaces inside link text : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md039.md",
+      "type": "boolean"
+    },
+    "no-trailing-punctuation": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD026/no-trailing-punctuation : Trailing punctuation in heading : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md026.md",
+      "properties": {
+        "punctuation": {
+          "default": ".,;:!\u3002\uff0c\uff1b\uff1a\uff01",
+          "description": "Punctuation characters",
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "no-trailing-spaces": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD009/no-trailing-spaces : Trailing spaces : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md009.md",
+      "properties": {
+        "br_spaces": {
+          "default": 2,
+          "description": "Spaces for line break",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "list_item_empty_lines": {
+          "default": false,
+          "description": "Allow spaces for empty lines in list items",
+          "type": "boolean"
+        },
+        "strict": {
+          "default": false,
+          "description": "Include unnecessary breaks",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "ol": {
+      "default": true,
+      "description": "ol : MD029, MD030, MD032",
+      "type": "boolean"
+    },
+    "ol-prefix": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD029/ol-prefix : Ordered list item prefix : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md029.md",
+      "properties": {
+        "style": {
+          "default": "one_or_ordered",
+          "description": "List style",
+          "enum": [
+            "one",
+            "ordered",
+            "one_or_ordered",
+            "zero"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "proper-names": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD044/proper-names : Proper names should have the correct capitalization : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md044.md",
+      "properties": {
+        "code_blocks": {
+          "default": true,
+          "description": "Include code blocks",
+          "type": "boolean"
+        },
+        "html_elements": {
+          "default": true,
+          "description": "Include HTML elements",
+          "type": "boolean"
+        },
+        "names": {
+          "default": [],
+          "description": "List of proper names",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "reference-links-images": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD052/reference-links-images : Reference links and images should use a label that is defined : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md052.md",
+      "properties": {
+        "shortcut_syntax": {
+          "default": false,
+          "description": "Include shortcut syntax",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "required-headings": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD043/required-headings : Required heading structure : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md043.md",
+      "properties": {
+        "headings": {
+          "default": [],
+          "description": "List of headings",
+          "items": {
+            "pattern": "^(\\*|\\+|#{1,6} .*)$",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "match_case": {
+          "default": false,
+          "description": "Match case of headings",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "single-h1": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md025.md",
+      "properties": {
+        "front_matter_title": {
+          "default": "^\\s*title\\s*[:=]",
+          "description": "RegExp for matching title in front matter",
+          "type": "string"
+        },
+        "level": {
+          "default": 1,
+          "description": "Heading level",
+          "maximum": 6,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "single-title": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md025.md",
+      "properties": {
+        "front_matter_title": {
+          "default": "^\\s*title\\s*[:=]",
+          "description": "RegExp for matching title in front matter",
+          "type": "string"
+        },
+        "level": {
+          "default": 1,
+          "description": "Heading level",
+          "maximum": 6,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "single-trailing-newline": {
+      "default": true,
+      "description": "MD047/single-trailing-newline : Files should end with a single newline character : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md047.md",
+      "type": "boolean"
+    },
+    "spaces": {
+      "default": true,
+      "description": "spaces : MD018, MD019, MD020, MD021, MD023",
+      "type": "boolean"
+    },
+    "spelling": {
+      "default": true,
+      "description": "spelling : MD044",
+      "type": "boolean"
+    },
+    "strong-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD050/strong-style : Strong style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md050.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Strong style",
+          "enum": [
+            "consistent",
+            "asterisk",
+            "underscore"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "table": {
+      "default": true,
+      "description": "table : MD055, MD056, MD058",
+      "type": "boolean"
+    },
+    "table-column-count": {
+      "default": true,
+      "description": "MD056/table-column-count : Table column count : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md056.md",
+      "type": "boolean"
+    },
+    "table-pipe-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD055/table-pipe-style : Table pipe style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md055.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "Table pipe style",
+          "enum": [
+            "consistent",
+            "leading_only",
+            "trailing_only",
+            "leading_and_trailing",
+            "no_leading_or_trailing"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "ul": {
+      "default": true,
+      "description": "ul : MD004, MD005, MD007, MD030, MD032",
+      "type": "boolean"
+    },
+    "ul-indent": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD007/ul-indent : Unordered list indentation : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md007.md",
+      "properties": {
+        "indent": {
+          "default": 2,
+          "description": "Spaces for indent",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "start_indent": {
+          "default": 2,
+          "description": "Spaces for first level indent (when start_indented is set)",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "start_indented": {
+          "default": false,
+          "description": "Whether to indent the first level of the list",
+          "type": "boolean"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "ul-style": {
+      "additionalProperties": false,
+      "default": true,
+      "description": "MD004/ul-style : Unordered list style : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md004.md",
+      "properties": {
+        "style": {
+          "default": "consistent",
+          "description": "List style",
+          "enum": [
+            "consistent",
+            "asterisk",
+            "plus",
+            "dash",
+            "sublist"
+          ],
+          "type": "string"
+        }
+      },
+      "type": [
+        "boolean",
+        "object"
+      ]
+    },
+    "url": {
+      "default": true,
+      "description": "url : MD034",
+      "type": "boolean"
+    },
+    "whitespace": {
+      "default": true,
+      "description": "whitespace : MD009, MD010, MD012, MD027, MD028, MD030, MD037, MD038, MD039",
+      "type": "boolean"
+    }
+  },
+  "title": "markdownlint configuration schema",
+  "type": "object"
+}

--- a/schemas/pre-commit-config.json
+++ b/schemas/pre-commit-config.json
@@ -1,0 +1,278 @@
+{
+  "$id": "https://json.schemastore.org/pre-commit-config.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "hook_definition": {
+      "properties": {
+        "additional_dependencies": {
+          "description": "A list of additional_dependencies of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "alias": {
+          "description": "An additional identifier of the current hook for `pre-commit run <hookid>`\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "always_run": {
+          "description": "Run the current hook when no files matched\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "boolean"
+        },
+        "args": {
+          "description": "List of additional parameters to pass to the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "entry": {
+          "description": "A command of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "exclude": {
+          "description": "A pattern to exclude files from `files` to run on of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "exclude_types": {
+          "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/file_types",
+          "description": "A list of file types to exclude of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks"
+        },
+        "files": {
+          "description": "A pattern to include files to run on of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "id": {
+          "description": "An identifier of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "language": {
+          "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/language",
+          "description": "A language the current hook is written in\nhttps://pre-commit.com/#pre-commit-configyaml---hooks"
+        },
+        "language_version": {
+          "description": "A language version of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "log_file": {
+          "description": "A log file of the current hook",
+          "type": "string"
+        },
+        "name": {
+          "description": "A name of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "string"
+        },
+        "pass_filenames": {
+          "default": true,
+          "description": "Whether to pass filenames to the current hook or not\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "boolean"
+        },
+        "stages": {
+          "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/stages",
+          "description": "A stage of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks"
+        },
+        "types": {
+          "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/file_types",
+          "description": "A list of file types to run on combined via logical `and` of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks"
+        },
+        "types_or": {
+          "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/file_types",
+          "description": "A list of file types to run on combined via logical `or` of the current hook\nhttps://pre-commit.com/#pre-commit-configyaml---hooks"
+        },
+        "verbose": {
+          "description": "Display an output of the current hook even it passes\nhttps://pre-commit.com/#pre-commit-configyaml---hooks",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "local_repo": {
+      "properties": {
+        "hooks": {
+          "items": {
+            "$ref": "#/definitions/hook_definition",
+            "required": [
+              "id",
+              "name",
+              "entry",
+              "language"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "repo": {
+          "default": "local",
+          "description": "A list of local hooks\nhttps://pre-commit.com/#2-add-a-pre-commit-configuration",
+          "enum": [
+            "local"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "meta_repo": {
+      "properties": {
+        "hooks": {
+          "items": {
+            "properties": {
+              "id": {
+                "enum": [
+                  "check-hooks-apply",
+                  "check-useless-excludes",
+                  "identity"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "repo": {
+          "default": "meta",
+          "enum": [
+            "meta"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "uri_repo": {
+      "properties": {
+        "hooks": {
+          "description": "A list of hook mappings\nhttps://pre-commit.com/#pre-commit-configyaml---hooks.",
+          "items": {
+            "$ref": "#/definitions/hook_definition",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "repo": {
+          "description": "A repository url\nhttps://pre-commit.com/#2-add-a-pre-commit-configuration",
+          "pattern": "^(?!(?:meta|local)$).*$",
+          "type": "string"
+        },
+        "rev": {
+          "description": "A revision or tag to clone at\nhttps://pre-commit.com/#2-add-a-pre-commit-configuration",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "ci": {
+      "description": "pre-commit.ci specific settings\nhttps://pre-commit.ci/#configuration",
+      "properties": {
+        "autofix_commit_msg": {
+          "default": "[pre-commit.ci] auto fixes from pre-commit.com hooks\n\nfor more information, see https://pre-commit.ci",
+          "description": "A commit message for pull request autofixes\nhttps://pre-commit.ci/#configuration",
+          "type": "string"
+        },
+        "autofix_prs": {
+          "default": true,
+          "description": "Whether to autofix pull requests\nhttps://pre-commit.ci/#configuration",
+          "type": "boolean"
+        },
+        "autoupdate_branch": {
+          "default": "",
+          "description": "A branch to send pull request's autoupdate to\nhttps://pre-commit.ci/#configuration",
+          "type": "string"
+        },
+        "autoupdate_commit_msg": {
+          "default": "[pre-commit.ci] pre-commit autoupdate",
+          "description": "A commit message for autoupdate pull requests\nhttps://pre-commit.ci/#configuration",
+          "type": "string"
+        },
+        "autoupdate_schedule": {
+          "default": "weekly",
+          "description": "An autoupdate frequency\nhttps://pre-commit.ci/#configuration",
+          "enum": [
+            "weekly",
+            "monthly",
+            "quarterly"
+          ],
+          "type": "string"
+        },
+        "skip": {
+          "description": "List of skipped hook's ids\nhttps://pre-commit.ci/#configuration",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "submodules": {
+          "default": false,
+          "description": "Whether to recursively check out submodules\nhttps://pre-commit.ci/#configuration",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "default_install_hook_types": {
+      "default": [
+        "pre-commit"
+      ],
+      "description": "A list of hook types which will be used by default when running `pre-commit install`\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "array"
+    },
+    "default_language_version": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Mappings for the default language versions of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "object"
+    },
+    "default_stages": {
+      "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/stages",
+      "description": "The default stages of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level"
+    },
+    "exclude": {
+      "default": "^$",
+      "description": "A file exclude pattern of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "string"
+    },
+    "fail_fast": {
+      "default": false,
+      "description": "Whether stop running hooks after a first failure\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "boolean"
+    },
+    "files": {
+      "default": "",
+      "description": "A file include pattern of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "string"
+    },
+    "minimum_pre_commit_version": {
+      "default": "0",
+      "description": "A minimum version of pre-commit\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "string"
+    },
+    "repos": {
+      "description": "Repository mappings of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/meta_repo"
+          },
+          {
+            "$ref": "#/definitions/local_repo"
+          },
+          {
+            "$ref": "#/definitions/uri_repo"
+          }
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "repos"
+  ],
+  "title": "JSON schema for .pre-commit-config.yaml",
+  "type": "object"
+}

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,16 @@
+quiet: true
+
+scan:
+  skip-dirs:
+    - "**/.terraform"
+    - "s3-prefix*"
+    - "simple"
+    - "examples/*"
+misconfiguration:
+  scanners:
+    - terraform
+
+  terraform:
+    exclude-downloaded-modules: true
+
+ignorefile: ".trivyignore.yaml"

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,11 @@
+variable "additional_security_groups" {
+  description = "A list of additional Security Groups to attach to the ALB."
+  type        = list(string)
+  default     = null
+}
+
 variable "alb_certificate_arns" {
-  description = "The ARNs of the certificates to be attached to the ALB."
+  description = "The ARNs of the additional certificates to be attached to the HTTPS Listener on the ALB. Does not replace the default certifcate on the listener (`var.alb_default_certificate_arn`)."
   type        = list(string)
   default     = []
 }
@@ -22,9 +28,9 @@ variable "alb_internal" {
 }
 
 variable "alb_ssl_policy" {
-  description = "The SSL policy (aka security policy) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies>."
+  description = "The SSL policy (aka security policy) for the Application Load Balancer that specifies the TLS protocols and ciphers allowed.  See [https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html)"
   type        = string
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 }
 
 variable "alb_subnet_ids" {
@@ -38,13 +44,13 @@ variable "alb_vpc_id" {
 }
 
 variable "allow_public_http" {
-  description = "Allow inbound access from the Internet to port 80"
+  description = "Allow inbound access from the Internet to port 80."
   type        = string
   default     = true
 }
 
 variable "allow_public_https" {
-  description = "Allow inbound access from the Internet to port 443"
+  description = "Allow inbound access from the Internet to port 443."
   type        = string
   default     = true
 }
@@ -74,14 +80,38 @@ variable "deregistration_delay" {
 }
 
 variable "desync_mitigation_mode" {
-  description = "Specifies how the load balancer handles security issues related to HTTP desync"
+  description = "How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are monitor, defensive (default), strictest."
   type        = string
   default     = "defensive"
 }
 
+variable "drop_invalid_header_fields" {
+  description = "Whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is true. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens."
+  type        = bool
+  default     = true
+}
+
+variable "enable_access_logs" {
+  description = "Enable ALB Access Logs."
+  type        = bool
+  default     = false
+}
+
+variable "enable_connection_logs" {
+  description = "Enable ALB Connection Logs."
+  type        = bool
+  default     = false
+}
+
 variable "enable_deletion_protection" {
-  description = " If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer"
-  type        = string
+  description = " If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancera."
+  type        = bool
+  default     = false
+}
+
+variable "enable_waf_fail_open" {
+  description = "Whether to allow a WAF-enabled load balancer to route requests to targets if it is unable to forward the request to AWS WAF. Defaults to false."
+  type        = bool
   default     = false
 }
 
@@ -127,8 +157,9 @@ variable "load_balancing_algorithm_type" {
 }
 
 variable "logs_s3_bucket" {
-  description = "S3 bucket for storing access logs. Set to empty string to disable logs."
+  description = "S3 bucket for storing access logs."
   type        = string
+  default     = null
 }
 
 variable "logs_s3_prefix" {
@@ -148,10 +179,16 @@ variable "name" {
   type        = string
 }
 
+variable "preserve_host_header" {
+  description = "Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change."
+  type        = bool
+  default     = false
+}
+
 variable "security_group" {
-  description = "SG for the ALB"
+  description = "User-defined Security Group for the ALB. Defining a Security Group here will cause the module to not create a Security Group for the ALB."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "security_group_tags" {
@@ -167,7 +204,7 @@ variable "slow_start" {
 }
 
 variable "target_group_name" {
-  description = "Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[protocol]."
+  description = "Override the default name of the ALB's target group. Must be less than or equal to 32 characters. Default: `ecs-[name]-[environment]-HTTPS`."
   type        = string
   default     = ""
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
#150 Introduces breaking changes. While I believe the changes should exist, short of quite a bit more effort, there isn't an upgrade path for users of the existing module where the changes that exist in this update provide. So this is a compromise. 

I had imagined cutting two releases. 

- `v10.1.0` (this one) which would allow users of the existing module to reap these benefits without further work (maybe setting appropriate variables).
- `v11.0.0` (#150). This would allow anyone adopting the module for the first time to not have to deal with the breaking changes that exist as a result of the changes.

Long-term, I don't want to manage two branches.

I can add something to the existing `README` on both releases that talks about the versions and usage for both. 

Closes:
- #125

Additions:

- Adds support for Connection Logging on the ALB, disabled by default.
- In addition to passing in a bucket name with `logs_s3_bucket`, the bool `enable_access_logs` and `enable_connection_logs` (both default to `false`) need to be set to `true` to enable logging of either type.
- Supports adding the ALB to additional security groups.
- Changed the default `alb_ssl_policy` to `ELBSecurityPolicy-TLS13-1-2-2021-06`.
- Added `enable_waf_fail_open` with a default value of `false`.
- Added `preserve_host_header` variable with a default value of `false`.
- Added `drop_invalid_host_headers` variable with default value of `true`.

**POTENTIAL BREAKING CHANGES**
- This pins AWS Provider to `~> 5.0`.

General Housekeeping

- Trivy support has been added, but not to `.pre-commit-config.yaml` because it is not possible to ignore the `examples` directory. So a target `check` has been added to the `Makefile`.
- Markdown Lint Pre-Commit was Replaced with [Markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
- Added Schema validation with `check-jsonschema` pre-commit for `.pre-commit-config.yaml`, `.markdownlint.yml` and `renovate` along with `github-workflows` (which is their name for Actions).
- I've fought quite a bit with our CI/CD tooling. I _think_ I finally got it. This uses a pre-commit-hook of `terraform-docs-system` which has an expectation that `terraform-docs` is installed locally. This also uses the official GitHub [Action](https://github.com/terraform-docs/gh-actions) but there is a [bug](https://github.com/terraform-docs/gh-actions/issues/136#issuecomment-2515368599). So across the org, I've tried to find the right configuration adopting the official action along with pre-commit-hook and making it work everywhere. I believe this combination works. `terraform-docs` will still continue to work locally, but in GitHub Actions, we pass an ENV VAR of `SKIP=terraform-system-go` to not call `terraform-docs` a second time via pre-commit. 
